### PR TITLE
Use "official" directory for persistent data

### DIFF
--- a/src/main/java/com/nutomic/syncthingandroid/syncthing/SyncthingService.java
+++ b/src/main/java/com/nutomic/syncthingandroid/syncthing/SyncthingService.java
@@ -28,6 +28,7 @@ import java.io.BufferedReader;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -236,9 +237,22 @@ public class SyncthingService extends Service {
 	}
 
 	/**
-	 * Move config files from old versions to "official" folder
+	 * Move config file, keys, and index files to "official" folder
+     *
+     * Note: Intended to bring the file locations in older installs in line with
+     *       newer versions.
 	 */
 	private void moveConfigFiles() {
+		FilenameFilter idxFilter = new FilenameFilter() {
+			public boolean accept(File dir, String name) {
+				if (name.endsWith(".idx.gz")) {
+					return true;
+				} else {
+					return false;
+				}
+			}
+		};
+
 		if (new File(getApplicationInfo().dataDir, PUBLIC_KEY_FILE).exists()) {
 			try {
 				File publicKey = new File(getApplicationInfo().dataDir, PUBLIC_KEY_FILE);
@@ -247,6 +261,14 @@ public class SyncthingService extends Service {
 				privateKey.renameTo(new File(getFilesDir(), PRIVATE_KEY_FILE));
 				File config = new File(getApplicationInfo().dataDir, CONFIG_FILE);
 				config.renameTo(new File(getFilesDir(), CONFIG_FILE));
+
+                File oldStorageDir = new File(getApplicationInfo().dataDir);
+                File[] files = oldStorageDir.listFiles(idxFilter);
+                for (File file : files) {
+                    if (file.isFile()) {
+                        file.renameTo(new File(getFilesDir(), file.getName()));
+                    }
+                }
 			}
 			catch (Exception e) {
 				Log.e(TAG, "Failed to move config files", e);


### PR DESCRIPTION
ST-andr uses the folder returned by `getApplicationInfo().dataDir` to store persistent data.
However, the "[official](http://developer.android.com/guide/topics/data/data-storage.html#filesInternal)" folder is returned by the API function `getFilesDir()`.

The paths returned by those functions are `/data/data/appname/` and `/data/data/appname/files/` resp.

In most phones the first one works fine. However, in the Razr-i files that are not stored in a subdir, seems to get deleted when the phone is rebooted or an update is installed.

This pull request should correct the problem.

Please test this patch before merging, because:
- I can't test the `moveConfigFiles` part, because the files that should be moved are being deleted when I update and I start from zero anyway.
- I'm not sure that the call of `moveConfigFiles` is early enough.
- I'm new to Android programming - this is my first contribution to an Android project

I hope it works... Constantly re-entering my settings is tiresome :-)
