### PR TITLE
prioritize select_folder over create_folder (untested)

### DIFF
--- a/src/main/res/menu/folder_picker.xml
+++ b/src/main/res/menu/folder_picker.xml
@@ -5,13 +5,13 @@
 	xmlns:app="http://schemas.android.com/apk/res-auto" >
 
 	<item
-			android:id="@+id/create_folder"
-			android:title="@string/create_folder"
+			android:id="@+id/select"
+			android:title="@string/select_folder"
 			app:showAsAction="ifRoom" />
 
 	<item
-			android:id="@+id/select"
-			android:title="@string/select_folder"
+			android:id="@+id/create_folder"
+			android:title="@string/create_folder"
 			app:showAsAction="ifRoom" />
 
 </menu>


### PR DESCRIPTION
Hello!

On a Galaxy S2 (and presumable other phones with screens ca. 480px wide), the more important button is pushed into the menu by the less important one.

I hope simply reverting the order of the code lines fixes that.

Cheers :-)
