### PR TITLE
Project's owner changed, so the tip4commit link broke

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # syncthing-android
 
 [![current build status](https://travis-ci.org/syncthing/syncthing-android.svg?branch=master)](https://travis-ci.org/syncthing/syncthing-android)
-[![tip for next commit](https://tip4commit.com/projects/914.svg)](https://tip4commit.com/github/Nutomic/syncthing-android)
+[![tip for next commit](https://tip4commit.com/projects/914.svg)](https://tip4commit.com/github/syncthing/syncthing-android)
 
 A wrapper of [syncthing](https://github.com/syncthing/syncthing) for Android.
 


### PR DESCRIPTION
The banner still has the correct image link.