### PR TITLE
Compression is now a string instead of a boolean (fixes #245 and #239)

### DIFF
--- a/src/main/java/com/nutomic/syncthingandroid/fragments/DeviceSettingsFragment.java
+++ b/src/main/java/com/nutomic/syncthingandroid/fragments/DeviceSettingsFragment.java
@@ -8,6 +8,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.preference.CheckBoxPreference;
 import android.preference.EditTextPreference;
+import android.preference.ListPreference;
 import android.preference.Preference;
 import android.support.v4.preference.PreferenceFragment;
 import android.view.Menu;
@@ -47,7 +48,7 @@ public class DeviceSettingsFragment extends PreferenceFragment implements
 
     private EditTextPreference mAddresses;
 
-    private CheckBoxPreference mCompression;
+    private ListPreference mCompression;
 
     private CheckBoxPreference mIntroducer;
 
@@ -78,7 +79,7 @@ public class DeviceSettingsFragment extends PreferenceFragment implements
         mName.setOnPreferenceChangeListener(this);
         mAddresses = (EditTextPreference) findPreference("addresses");
         mAddresses.setOnPreferenceChangeListener(this);
-        mCompression = (CheckBoxPreference) findPreference("compression");
+        mCompression = (ListPreference) findPreference("compression");
         mCompression.setOnPreferenceChangeListener(this);
         mIntroducer = (CheckBoxPreference) findPreference("introducer");
         mIntroducer.setOnPreferenceChangeListener(this);
@@ -97,7 +98,7 @@ public class DeviceSettingsFragment extends PreferenceFragment implements
                 mDevice.Name = "";
                 mDevice.DeviceID = "";
                 mDevice.Addresses = "dynamic";
-                mDevice.Compression = true;
+                mDevice.Compression = "always";
                 ((EditTextPreference) mDeviceId).setText(mDevice.DeviceID);
             }
         }
@@ -148,7 +149,8 @@ public class DeviceSettingsFragment extends PreferenceFragment implements
         mName.setSummary(mDevice.Name);
         mAddresses.setText(mDevice.Addresses);
         mAddresses.setSummary(mDevice.Addresses);
-        mCompression.setChecked(mDevice.Compression);
+        mCompression.setValue(mDevice.Compression);
+        mCompression.setSummary(mDevice.Compression);
     }
 
     @Override
@@ -209,7 +211,6 @@ public class DeviceSettingsFragment extends PreferenceFragment implements
             EditTextPreference pref = (EditTextPreference) preference;
             pref.setSummary((String) o);
         }
-
         if (preference.equals(mDeviceId)) {
             mDevice.DeviceID = (String) o;
             deviceUpdated();
@@ -223,7 +224,7 @@ public class DeviceSettingsFragment extends PreferenceFragment implements
             deviceUpdated();
             return true;
         } else if (preference.equals(mCompression)) {
-            mDevice.Compression = (Boolean) o;
+            mDevice.Compression = (String) o;
             deviceUpdated();
             return true;
         } else if (preference.equals(mIntroducer)) {

--- a/src/main/java/com/nutomic/syncthingandroid/syncthing/RestApi.java
+++ b/src/main/java/com/nutomic/syncthingandroid/syncthing/RestApi.java
@@ -66,7 +66,7 @@ public class RestApi implements SyncthingService.OnWebGuiAvailableListener,
         public String Addresses;
         public String Name;
         public String DeviceID;
-        public boolean Compression;
+        public String Compression;
         public boolean Introducer;
     }
 
@@ -407,7 +407,7 @@ public class RestApi implements SyncthingService.OnWebGuiAvailableListener,
                 n.Addresses = json.optJSONArray("Addresses").join(" ").replace("\"", "");
                 n.Name = json.getString("Name");
                 n.DeviceID = json.getString("DeviceID");
-                n.Compression = json.getBoolean("Compression");
+                n.Compression = json.getString("Compression");
                 n.Introducer = json.getBoolean("Introducer");
                 if (includeLocal || !mLocalDeviceId.equals(n.DeviceID)) {
                     ret.add(n);

--- a/src/main/res/values/arrays.xml
+++ b/src/main/res/values/arrays.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources translatable="false">
+    <string-array name="compress_values">
+        <item>never</item>
+        <item>metadata</item>
+        <item>always</item>
+    </string-array>
+</resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -146,6 +146,13 @@
     <!-- Setting title -->
     <string name="compression">Compression</string>
 
+    <!-- Strings representing compression options -->
+    <string-array name="compress_entries">
+        <item>Never</item>
+        <item>Metadata</item>
+        <item>Always</item>
+    </string-array>
+
     <!-- Setting title -->
     <string name="introducer">Introducer</string>
 

--- a/src/main/res/xml/device_settings_create.xml
+++ b/src/main/res/xml/device_settings_create.xml
@@ -15,8 +15,10 @@
         android:key="addresses"
         android:title="@string/addresses" />
 
-    <CheckBoxPreference
+    <ListPreference
         android:key="compression"
+        android:entries="@array/compress_entries"
+        android:entryValues="@array/compress_values"
         android:title="@string/compression" />
 
     <CheckBoxPreference

--- a/src/main/res/xml/device_settings_edit.xml
+++ b/src/main/res/xml/device_settings_edit.xml
@@ -14,8 +14,10 @@
         android:key="addresses"
         android:title="@string/addresses" />
 
-    <CheckBoxPreference
+    <ListPreference
         android:key="compression"
+        android:entries="@array/compress_entries"
+        android:entryValues="@array/compress_values"
         android:title="@string/compression" />
 
     <CheckBoxPreference


### PR DESCRIPTION
Took me some time to get the correct preferences without loading the XML. If you load the XML it will crash because the original preference was a booleanpreference, which should become a listpreference.
Using ```SharedPreferences settings = activity.getPreferenceManager().getSharedPreferences();``` is the key ;)