### PR TITLE
Set announce color green if at least one is connected (fixes #249)

### DIFF
--- a/src/main/java/com/nutomic/syncthingandroid/fragments/DrawerFragment.java
+++ b/src/main/java/com/nutomic/syncthingandroid/fragments/DrawerFragment.java
@@ -182,12 +182,11 @@ public class DrawerFragment extends Fragment implements RestApi.OnReceiveSystemI
         });
         mCpuUsage.setText(new DecimalFormat("0.00").format(info.cpuPercent) + "%");
         mRamUsage.setText(RestApi.readableFileSize(mActivity, info.sys));
-        if (info.extAnnounceConnected == info.extAnnounceTotal) {
-            mAnnounceServer.setText(android.R.string.ok);
+        mAnnounceServer.setText(Integer.toString(info.extAnnounceConnected) + "/" +
+                Integer.toString(info.extAnnounceTotal));
+        if (info.extAnnounceConnected > 0) {
             mAnnounceServer.setTextColor(getResources().getColor(R.color.text_green));
         } else {
-            mAnnounceServer.setText(Integer.toString(info.extAnnounceConnected) + "/" +
-                    Integer.toString(info.extAnnounceTotal));
             mAnnounceServer.setTextColor(getResources().getColor(R.color.text_red));
         }
     }


### PR DESCRIPTION
As implemented in upstream, see https://github.com/syncthing/syncthing/commit/f15c416e590607b654c7c7e6408e48af11b39985
Feel free to reject if you don't agree. I'm not sure what is the best option here, but it will at least not scare ppl:)