### PR TITLE
Disable ST upgrade in runnable (fixes #276).

### DIFF
--- a/src/main/java/com/nutomic/syncthingandroid/syncthing/SyncthingRunnable.java
+++ b/src/main/java/com/nutomic/syncthingandroid/syncthing/SyncthingRunnable.java
@@ -51,6 +51,7 @@ public class SyncthingRunnable implements Runnable {
                 dos.writeBytes("HOME=" + Environment.getExternalStorageDirectory() + " ");
                 dos.writeBytes("STTRACE=" + pm.getString("sttrace", "") + " ");
                 dos.writeBytes("STNORESTART=1 ");
+                dos.writeBytes("STNOUPGRADE=1 ");
                 // Call syncthing with -home (as it would otherwise use "~/.config/syncthing/".
                 dos.writeBytes(mCommand + " -home " + mContext.getFilesDir() + "\n");
                 dos.writeBytes("exit\n");


### PR DESCRIPTION
We should be sure that ST does not try to upgrade, even if the user provides a custom config file.