### PR TITLE
Maintain&check reference to GUI before changing it

### DIFF
--- a/src/main/java/com/nutomic/syncthingandroid/activities/MainActivity.java
+++ b/src/main/java/com/nutomic/syncthingandroid/activities/MainActivity.java
@@ -49,7 +49,7 @@ public class MainActivity extends SyncthingActivity
     @Override
     @SuppressLint("InflateParams")
     public void onApiChange(SyncthingService.State currentState) {
-        if (currentState != SyncthingService.State.ACTIVE && !isFinishing()) {
+        if (currentState != SyncthingService.State.ACTIVE && !isFinishing() && !isDestroyed()) {
             if (currentState == SyncthingService.State.DISABLED) {
                 if (mLoadingDialog != null) {
                     mLoadingDialog.dismiss();


### PR DESCRIPTION
Probably fixes (Play store logs)
```
java.lang.RuntimeException: Unable to start service com.nutomic.syncthingandroid.syncthing.SyncthingService@140f4d5c with Intent { act=restart cmp=com.nutomic.syncthingandroid/.syncthing.SyncthingService }: android.view.WindowManager$BadTokenException: Unable to add window -- token android.os.BinderProxy@b108aa9 is not valid; is your activity running?
at android.app.ActivityThread.handleServiceArgs(ActivityThread.java:2881)
at android.app.ActivityThread.access$2100(ActivityThread.java:144)
at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1376)
at android.os.Handler.dispatchMessage(Handler.java:102)
at android.os.Looper.loop(Looper.java:135)
at android.app.ActivityThread.main(ActivityThread.java:5221)
at java.lang.reflect.Method.invoke(Native Method)
at java.lang.reflect.Method.invoke(Method.java:372)
at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:899)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:694)
Caused by: android.view.WindowManager$BadTokenException: Unable to add window -- token android.os.BinderProxy@b108aa9 is not valid; is your activity running?
at android.view.ViewRootImpl.setView(ViewRootImpl.java:562)
at android.view.WindowManagerGlobal.addView(WindowManagerGlobal.java:272)
at android.view.WindowManagerImpl.addView(WindowManagerImpl.java:69)
at android.app.Dialog.show(Dialog.java:298)
at android.app.AlertDialog$Builder.show(AlertDialog.java:987)
at com.nutomic.syncthingandroid.activities.MainActivity.onApiChange(MainActivity.java:72)
at com.nutomic.syncthingandroid.syncthing.SyncthingService.onApiChange(SyncthingService.java:397)
at com.nutomic.syncthingandroid.syncthing.SyncthingService.updateState(SyncthingService.java:227)
at com.nutomic.syncthingandroid.syncthing.SyncthingService.onStartCommand(SyncthingService.java:148)
at android.app.ActivityThread.handleServiceArgs(ActivityThread.java:2864)
... 9 more
```