### PR TITLE
Do not add visual content if activity is finishing (fixes #312).

### DIFF
--- a/src/main/java/com/nutomic/syncthingandroid/activities/FolderPickerActivity.java
+++ b/src/main/java/com/nutomic/syncthingandroid/activities/FolderPickerActivity.java
@@ -26,6 +26,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.nutomic.syncthingandroid.R;
+import com.nutomic.syncthingandroid.dialogs.AsyncDialogs;
 import com.nutomic.syncthingandroid.syncthing.SyncthingService;
 
 import java.io.File;
@@ -283,7 +284,7 @@ public class FolderPickerActivity extends SyncthingActivity
     public void onApiChange(SyncthingService.State currentState) {
         if (!isFinishing() && currentState != SyncthingService.State.ACTIVE) {
             setResult(Activity.RESULT_CANCELED);
-            SyncthingService.showDisabledDialog(this);
+            AsyncDialogs.showDisabledDialog(this);
             finish();
         }
     }

--- a/src/main/java/com/nutomic/syncthingandroid/dialogs/AsyncDialogs.java
+++ b/src/main/java/com/nutomic/syncthingandroid/dialogs/AsyncDialogs.java
@@ -1,0 +1,150 @@
+package com.nutomic.syncthingandroid.dialogs;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.AsyncTask;
+import android.preference.PreferenceManager;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.TextView;
+
+import com.nutomic.syncthingandroid.R;
+import com.nutomic.syncthingandroid.activities.SettingsActivity;
+
+/**
+ * Helper functions to start dialogs on the UI thread using an Async Task.
+ */
+public class AsyncDialogs {
+
+    /**
+     * Dialog to be shown when attempting to start Syncthing while it is disabled according
+     * to settings (because the device is not charging or wifi is disconnected).
+     */
+    public static AsyncTask showDisabledDialog(final Activity activity) {
+        AsyncTask a = new AsyncTask() {
+            AlertDialog dialog;
+
+            @Override
+            protected void onPreExecute() {
+                if (activity.isFinishing())
+                    return;
+                dialog = new AlertDialog.Builder(activity)
+                        .setTitle(R.string.syncthing_disabled_title)
+                        .setMessage(R.string.syncthing_disabled_message)
+                        .setCancelable(false)
+                        .setPositiveButton(R.string.syncthing_disabled_change_settings,
+                                new DialogInterface.OnClickListener() {
+                                    @Override
+                                    public void onClick(DialogInterface dialogInterface, int i) {
+                                        activity.finish();
+                                        Intent intent = new Intent(activity, SettingsActivity.class)
+                                                .setAction(SettingsActivity.ACTION_APP_SETTINGS_FRAGMENT);
+                                        activity.startActivity(intent);
+                                    }
+                                }
+                        )
+                        .setNegativeButton(R.string.exit,
+                                new DialogInterface.OnClickListener() {
+                                    @Override
+                                    public void onClick(DialogInterface dialogInterface, int i) {
+                                        activity.finish();
+                                    }
+                                }
+                        )
+                        .show();
+            }
+            @Override
+            protected Object doInBackground(Object[] params) {
+                return null;
+            }
+            @Override
+            protected void onCancelled() {
+                if (dialog.isShowing())
+                    dialog.dismiss();
+            }
+        };
+        return a.execute();
+    }
+
+    /**
+     * Dialog to be shown when Syncthing is loading and we're waiting for the API.
+     */
+    public static AsyncTask showLoadingDialog(final Activity activity, final boolean isCreating) {
+        AsyncTask a = new AsyncTask() {
+            AlertDialog dialog;
+
+            @Override
+            protected void onPreExecute() {
+                if (activity.isFinishing())
+                    return;
+
+                LayoutInflater inflater = activity.getLayoutInflater();
+                View dialogLayout = inflater.inflate(R.layout.loading_dialog, null);
+                TextView loadingText = (TextView) dialogLayout.findViewById(R.id.loading_text);
+                loadingText.setText(isCreating
+                        ? R.string.web_gui_creating_key
+                        : R.string.api_loading);
+
+                dialog = new AlertDialog.Builder(activity)
+                        .setCancelable(false)
+                        .setView(dialogLayout)
+                        .show();
+
+
+                // Make sure the welcome dialog is shown on top.
+                final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(activity);
+                if (prefs.getBoolean("first_start", true)) {
+                    new AlertDialog.Builder(activity)
+                            .setTitle(R.string.welcome_title)
+                            .setMessage(R.string.welcome_text)
+                            .setNeutralButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+                                @Override
+                                public void onClick(DialogInterface dialogInterface, int i) {
+                                    prefs.edit().putBoolean("first_start", false).commit();
+                                }
+                            }).show();
+                }
+            }
+            @Override
+            protected Object doInBackground(Object[] params) {
+                return null;
+            }
+            @Override
+            protected void onCancelled() {
+                if (dialog.isShowing())
+                    dialog.dismiss();
+            }
+        };
+        return a.execute();
+    }
+
+
+    /**
+     * Welcome dialog to be shown when the user launches the app for the first time.
+     */
+    public static AsyncTask showWelcomeDialog(final Activity activity) {
+        AsyncTask a = new AsyncTask() {
+            AlertDialog dialog;
+
+            @Override
+            protected void onPreExecute() {
+                if (activity.isFinishing())
+                    return;
+
+            }
+            @Override
+            protected Object doInBackground(Object[] params) {
+                return null;
+            }
+            @Override
+            protected void onCancelled() {
+                if (dialog.isShowing())
+                    dialog.dismiss();
+            }
+        };
+        return a.execute();
+    }
+}

--- a/src/main/java/com/nutomic/syncthingandroid/fragments/DeviceSettingsFragment.java
+++ b/src/main/java/com/nutomic/syncthingandroid/fragments/DeviceSettingsFragment.java
@@ -319,8 +319,9 @@ public class DeviceSettingsFragment extends PreferenceFragment implements
      */
     @Override
     public void onDeviceIdNormalized(String normalizedId, String error) {
-        if (error != null) {
-            Toast.makeText(getActivity(), error, Toast.LENGTH_LONG).show();
+        Activity act = getActivity();
+        if (error != null && !act.isFinishing()) {
+            Toast.makeText(act, error, Toast.LENGTH_LONG).show();
         }
     }
 

--- a/src/main/java/com/nutomic/syncthingandroid/fragments/DevicesFragment.java
+++ b/src/main/java/com/nutomic/syncthingandroid/fragments/DevicesFragment.java
@@ -54,7 +54,7 @@ public class DevicesFragment extends ListFragment implements SyncthingService.On
 
     private void initAdapter() {
         SyncthingActivity activity = (SyncthingActivity) getActivity();
-        if (activity == null || activity.getApi() == null)
+        if (activity == null || activity.getApi() == null || activity.isFinishing())
             return;
 
         mAdapter = new DevicesAdapter(activity);

--- a/src/main/java/com/nutomic/syncthingandroid/syncthing/RestApi.java
+++ b/src/main/java/com/nutomic/syncthingandroid/syncthing/RestApi.java
@@ -344,6 +344,11 @@ public class RestApi implements SyncthingService.OnWebGuiAvailableListener,
         final Intent intent = new Intent(mContext, SyncthingService.class)
                 .setAction(SyncthingService.ACTION_RESTART);
 
+        if (activity.isFinishing()) {
+            mContext.startService(intent);
+            return;
+        }
+
         AlertDialog.Builder builder = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB)
                 ? new AlertDialog.Builder(activity, AlertDialog.THEME_HOLO_LIGHT)
                 : new AlertDialog.Builder(activity);

--- a/src/main/java/com/nutomic/syncthingandroid/syncthing/SyncthingService.java
+++ b/src/main/java/com/nutomic/syncthingandroid/syncthing/SyncthingService.java
@@ -1,13 +1,10 @@
 package com.nutomic.syncthingandroid.syncthing;
 
-import android.app.Activity;
-import android.app.AlertDialog;
 import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
@@ -21,7 +18,6 @@ import android.util.Pair;
 
 import com.nutomic.syncthingandroid.R;
 import com.nutomic.syncthingandroid.activities.MainActivity;
-import com.nutomic.syncthingandroid.activities.SettingsActivity;
 import com.nutomic.syncthingandroid.util.ConfigXml;
 import com.nutomic.syncthingandroid.util.FolderObserver;
 
@@ -402,38 +398,6 @@ public class SyncthingService extends Service {
                 i.remove();
             }
         }
-    }
-
-    /**
-     * Dialog to be shown when attempting to start syncthing while it is disabled according
-     * to settings (because the device is not charging or wifi is disconnected).
-     */
-    public static AlertDialog showDisabledDialog(final Activity activity) {
-        AlertDialog dialog = new AlertDialog.Builder(activity)
-                .setTitle(R.string.syncthing_disabled_title)
-                .setMessage(R.string.syncthing_disabled_message)
-                .setPositiveButton(R.string.syncthing_disabled_change_settings,
-                        new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialogInterface, int i) {
-                                activity.finish();
-                                Intent intent = new Intent(activity, SettingsActivity.class)
-                                        .setAction(SettingsActivity.ACTION_APP_SETTINGS_FRAGMENT);
-                                activity.startActivity(intent);
-                            }
-                        }
-                )
-                .setNegativeButton(R.string.exit,
-                        new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialogInterface, int i) {
-                                activity.finish();
-                            }
-                        }
-                )
-                .show();
-        dialog.setCancelable(false);
-        return dialog;
     }
 
     public String getWebGuiUrl() {


### PR DESCRIPTION
- I did a check on all fragments for use-while-finishing usage patterns
- If it is finishing and we need to restart, we just restart.