### PR TITLE
Capture invalid/failed Syncthing responses (fixes #291).

### DIFF
--- a/src/main/java/com/nutomic/syncthingandroid/syncthing/RestApi.java
+++ b/src/main/java/com/nutomic/syncthingandroid/syncthing/RestApi.java
@@ -204,6 +204,8 @@ public class RestApi implements SyncthingService.OnWebGuiAvailableListener,
         new GetTask() {
             @Override
             protected void onPostExecute(String s) {
+                if (s == null)
+                    return;
                 try {
                     JSONObject json = new JSONObject(s);
                     mVersion = json.getString("version");
@@ -218,6 +220,8 @@ public class RestApi implements SyncthingService.OnWebGuiAvailableListener,
         new GetTask() {
             @Override
             protected void onPostExecute(String config) {
+                if (config == null)
+                    return;
                 try {
                     mConfig = new JSONObject(config);
                     tryIsAvailable();
@@ -877,6 +881,8 @@ public class RestApi implements SyncthingService.OnWebGuiAvailableListener,
             @Override
             protected void onPostExecute(String s) {
                 super.onPostExecute(s);
+                if (s == null)
+                    return;
                 String normalized = null;
                 String error = null;
                 try {


### PR DESCRIPTION
From the JSON documentation: ```Null is not permitted and will yield a tokener that throws {@code NullPointerExceptions} when methods are called.```

We should capture failed requests or empty responses ourselves.