### PR TITLE
Ensure Syncthing is not running (fixes #92 and #96)

### DIFF
--- a/src/main/java/com/nutomic/syncthingandroid/fragments/DrawerFragment.java
+++ b/src/main/java/com/nutomic/syncthingandroid/fragments/DrawerFragment.java
@@ -233,7 +233,6 @@ public class DrawerFragment extends Fragment implements RestApi.OnReceiveSystemI
                 mActivity.closeDrawer();
                 break;
             case 4:
-                mActivity.getService().getApi().shutdown();
                 mActivity.stopService(new Intent(mActivity, SyncthingService.class));
                 mActivity.finish();
                 mActivity.closeDrawer();

--- a/src/main/java/com/nutomic/syncthingandroid/syncthing/PostTask.java
+++ b/src/main/java/com/nutomic/syncthingandroid/syncthing/PostTask.java
@@ -21,8 +21,6 @@ public class PostTask extends AsyncTask<String, Void, Boolean> {
 
     public static final String URI_CONFIG = "/rest/config";
 
-    public static final String URI_SHUTDOWN = "/rest/shutdown";
-
     public static final String URI_SCAN = "/rest/scan";
 
     /**

--- a/src/main/java/com/nutomic/syncthingandroid/syncthing/RestApi.java
+++ b/src/main/java/com/nutomic/syncthingandroid/syncthing/RestApi.java
@@ -11,6 +11,7 @@ import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.os.AsyncTask;
 import android.os.Build;
 import android.support.v4.app.NotificationCompat;
 import android.util.Log;
@@ -31,6 +32,9 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -267,7 +271,7 @@ public class RestApi implements SyncthingService.OnWebGuiAvailableListener,
         NotificationManager nm = (NotificationManager)
                 mContext.getSystemService(Context.NOTIFICATION_SERVICE);
         nm.cancel(NOTIFICATION_RESTART);
-        new PostTask().execute(mUrl, PostTask.URI_SHUTDOWN, mApiKey);
+        SyncthingRunnable.killSyncthing();
         mRestartPostponed = false;
     }
 


### PR DESCRIPTION
Ensure Syncthing is not running
- Fixes a bug: api.shutdown() is called asynchronously (line 278)
- Kills Syncthing processes on shutdown (e.g. when the /rest/shutdown call could not be applied because ST was too busy).
