### PR TITLE
Fix NPE when Async call completes after fragment was closed

### DIFF
--- a/src/main/java/com/nutomic/syncthingandroid/fragments/DeviceSettingsFragment.java
+++ b/src/main/java/com/nutomic/syncthingandroid/fragments/DeviceSettingsFragment.java
@@ -270,6 +270,8 @@ public class DeviceSettingsFragment extends PreferenceFragment implements
      */
     @Override
     public void onReceiveConnections(Map<String, RestApi.Connection> connections) {
+        if (mVersion == null || mCurrentAddress == null)
+            return;
         if (connections.containsKey(mDevice.DeviceID)) {
             mVersion.setSummary(connections.get(mDevice.DeviceID).ClientVersion);
             mCurrentAddress.setSummary(connections.get(mDevice.DeviceID).Address);


### PR DESCRIPTION
So I think the only way mDevice can be null in this case is because the fragment is destroyed and then the connection update happens.