### PR TITLE
Added option to run syncthing as root (fixes #48).

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,13 +19,15 @@ apply plugin: 'com.github.ben-manes.versions'
 repositories {
     mavenCentral()
     maven {
-        url {
-            'https://raw.github.com/kolavar/android-support-v4-preferencefragment/master/maven-repository/'
-        }
+        url 'https://raw.github.com/kolavar/android-support-v4-preferencefragment/master/maven-repository/'
+    }
+    maven {
+        url 'http://jcenter.bintray.com'
     }
 }
 
 dependencies {
+    compile 'eu.chainfire:libsuperuser:1.0.0.201504231659'
     compile 'com.android.support:appcompat-v7:22.0.0'
     compile 'com.android.support:support-v4-preferencefragment:1.0.0@aar'
     androidTestCompile 'com.squareup.okhttp:mockwebserver:2.3.0'

--- a/src/main/java/com/nutomic/syncthingandroid/syncthing/RestApi.java
+++ b/src/main/java/com/nutomic/syncthingandroid/syncthing/RestApi.java
@@ -267,7 +267,7 @@ public class RestApi implements SyncthingService.OnWebGuiAvailableListener,
     }
 
     /**
-     * Stops syncthing. You should probably use SyncthingService.stopService() instead.
+     * Stops syncthing and cancels notification. For use by {@link SyncthingService}.
      */
     public void shutdown() {
         // Happens in unit tests.
@@ -277,7 +277,6 @@ public class RestApi implements SyncthingService.OnWebGuiAvailableListener,
         NotificationManager nm = (NotificationManager)
                 mContext.getSystemService(Context.NOTIFICATION_SERVICE);
         nm.cancel(NOTIFICATION_RESTART);
-        SyncthingRunnable.killSyncthing();
         mRestartPostponed = false;
     }
 
@@ -740,7 +739,7 @@ public class RestApi implements SyncthingService.OnWebGuiAvailableListener,
             case "":         return c.getString(R.string.state_unknown);
         }
         if (BuildConfig.DEBUG) {
-            throw new AssertionError("Unexpected folder state");
+            throw new AssertionError("Unexpected folder state " + state);
         }
         return "";
     }

--- a/src/main/res/xml/app_settings.xml
+++ b/src/main/res/xml/app_settings.xml
@@ -25,6 +25,12 @@
             android:summary="@string/advanced_folder_picker_summary"
             android:defaultValue="false" />
 
+        <CheckBoxPreference
+            android:key="use_root"
+            android:title="Sync as root"
+            android:summary="Run syncthing as superuser"
+            android:defaultValue="false" />
+
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
Right now, it breaks when switching from `root` to `non-root`, because index files are then owned by root. Is there a better option than manually running chown on setting change?

I haven't tested without root, we should check that the setting is really hidden in that case.

