### PR TITLE
Asynchronous event API

### DIFF
--- a/src/main/java/com/nutomic/syncthingandroid/syncthing/EventProcessor.java
+++ b/src/main/java/com/nutomic/syncthingandroid/syncthing/EventProcessor.java
@@ -1,0 +1,190 @@
+package com.nutomic.syncthingandroid.syncthing;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.preference.PreferenceManager;
+import android.support.v4.content.LocalBroadcastManager;
+import android.util.Log;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Run by the syncthing service to convert syncthing events into local broadcasts.
+ * It uses SyncthingService.GetEvents to read the pending events and wait for new events.
+ */
+public class EventProcessor implements SyncthingService.OnWebGuiAvailableListener, Runnable,
+        RestApi.OnReceiveEventListener {
+
+    private static final String TAG = "EventProcessor";
+    private static final String PREF_LAST_SYNC_ID = "last_sync_id";
+
+    private static final String EVENT_BASE_ACTION = "com.nutomic.syncthingandroid.event";
+
+    /**
+     * Minimum interval in seconds at which the events are polled from syncthing and processed.
+     * This intervall will not wake up the device to save battery power.
+     */
+    public static final long EVENT_UPDATE_INTERVAL = TimeUnit.SECONDS.toMillis(15);
+
+    // Use the MainThread for all callbacks and message handling
+    // or we have to track down nasty threading problems.
+    private final Handler mMainThreadHandler = new Handler(Looper.getMainLooper());
+
+    private volatile long mLastEventId = 0;
+    private volatile boolean mShutdown = true;
+
+    private final Context mContext;
+    private final RestApi mApi;
+    private final LocalBroadcastManager mLocalBM;
+    private final Map<String, String> mFolderToPath = new HashMap<>();
+
+    /**
+     * Returns the action used by notification Intents fired for the given Syncthing event.
+     * @param eventName Name of the Syncthing event.
+     * @return Returns the full intent action used for local broadcasts.
+     */
+    public static String getEventIntentAction(String eventName) {
+        return EVENT_BASE_ACTION + "." + eventName.toUpperCase();
+    }
+
+    /**
+     * C'tor
+     * @param context Context of the service using this event processor.
+     * @param api Reference to the RestApi-Instance used for all API calls by this instance of the
+     *            Event processor.
+     */
+    public EventProcessor(Context context, RestApi api) {
+        mContext = context;
+        mApi = api;
+        mLocalBM = LocalBroadcastManager.getInstance(mContext);
+    }
+
+    private void updateFolderMap()
+    {
+        synchronized(mFolderToPath) {
+            mFolderToPath.clear();
+            for (RestApi.Folder folder: mApi.getFolders()) {
+                mFolderToPath.put(folder.id, folder.path);
+            }
+        }
+    }
+
+    /**
+     * @see Runnable
+     */
+    @Override
+    public void run() {
+        // Restore the last event id if the event processor may have been restartet.
+        if (mLastEventId == 0) {
+            mLastEventId = PreferenceManager.getDefaultSharedPreferences(mContext)
+                    .getLong(PREF_LAST_SYNC_ID, 0);
+        }
+
+        // First check if the event number ran backwards.
+        // If that's the case we've to start at zero because syncthing was restartet.
+        mApi.getEvents(0, 1, new RestApi.OnReceiveEventListener() {
+            @Override
+            public void onEvent(long id, String eventType, Bundle eventData) {
+            }
+
+            @Override
+            public void onDone(long lastId) {
+                if (lastId < mLastEventId) mLastEventId = 0;
+
+                Log.d(TAG, "Reading events starting with id " + mLastEventId);
+
+                mApi.getEvents(mLastEventId, 0, EventProcessor.this);
+            }
+        });
+    }
+
+    /**
+     * @see RestApi.OnReceiveEventListener
+     */
+    @Override
+    public void onEvent(final long id, final String eventType, final Bundle eventData) {
+        // If a folder item is contained within the event. Resolve the local path.
+        if (eventData.containsKey("folder")) {
+            String folderPath = null;
+            synchronized (mFolderToPath) {
+                if (mFolderToPath.size() == 0) updateFolderMap();
+                folderPath = mFolderToPath.get(eventData.getString("folder"));
+            }
+
+            if (folderPath != null) {
+                eventData.putString("_localFolderPath",folderPath);
+
+                if (eventData.containsKey("item")) {
+                    final File file = new File(new File(folderPath), eventData.getString("item"));
+
+                    eventData.putString("_localItemPath", file.getPath());
+                }
+            }
+        }
+
+        final Intent eventBroadcastItent = new Intent(EVENT_BASE_ACTION + "." + eventType.toUpperCase());
+        eventBroadcastItent.putExtras(eventData);
+        mLocalBM.sendBroadcast(eventBroadcastItent);
+
+        Log.d(TAG,
+                "Sent local event broadcast " + eventBroadcastItent.getAction() +
+                " including " + eventType.length() + " extra data items."
+        );
+    }
+
+    /**
+     * @see RestApi.OnReceiveEventListener
+     */
+    @Override
+    public void onDone(long id) {
+        if (mLastEventId < id) {
+            mLastEventId = id;
+
+            // Store the last EventId in case we get killed
+            final SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(mContext);
+
+            //noinspection CommitPrefEdits
+            sp.edit().putLong(PREF_LAST_SYNC_ID, mLastEventId).commit();
+        }
+
+        synchronized (mMainThreadHandler) {
+            if (!mShutdown) {
+                mMainThreadHandler.removeCallbacks(this);
+                mMainThreadHandler.postDelayed(this, EVENT_UPDATE_INTERVAL);
+            }
+        }
+    }
+
+    /**
+     * @see SyncthingService.OnWebGuiAvailableListener
+     */
+    @Override
+    public void onWebGuiAvailable() {
+        Log.d(TAG, "WebGUI available. Starting event processor.");
+
+        updateFolderMap();
+
+        // Remove all pending callbacks and add a new one. This makes sure that only one
+        // event poller is running at any given time.
+        synchronized (mMainThreadHandler) {
+            mShutdown = false;
+            mMainThreadHandler.removeCallbacks(this);
+            mMainThreadHandler.postDelayed(this, EVENT_UPDATE_INTERVAL);
+        }
+    }
+
+    public void shutdown() {
+        Log.d(TAG, "Shutdown event processor.");
+        synchronized (mMainThreadHandler) {
+            mShutdown = true;
+            mMainThreadHandler.removeCallbacks(this);
+        }
+    }
+}

--- a/src/main/java/com/nutomic/syncthingandroid/syncthing/GetTask.java
+++ b/src/main/java/com/nutomic/syncthingandroid/syncthing/GetTask.java
@@ -36,6 +36,7 @@ public class GetTask extends AsyncTask<String, Void, String> {
     public static final String URI_MODEL       = "/rest/db/status";
     public static final String URI_DEVICEID    = "/rest/svc/deviceid";
     public static final String URI_REPORT      = "/rest/svc/report";
+    public static final String URI_EVENTS      = "/rest/events";
 
     private String mHttpsCertPath;
 
@@ -55,9 +56,11 @@ public class GetTask extends AsyncTask<String, Void, String> {
         String fullUri = params[0] + params[1];
         Log.v(TAG, "Calling Rest API at " + fullUri);
 
-        if (params.length == 5) {
+        if (params.length >= 5) {
             LinkedList<NameValuePair> urlParams = new LinkedList<>();
-            urlParams.add(new BasicNameValuePair(params[3], params[4]));
+            for (int paramCounter = 3; paramCounter + 1 < params.length; ) {
+                urlParams.add(new BasicNameValuePair(params[paramCounter++], params[paramCounter++]));
+            }
             fullUri += "?" + URLEncodedUtils.format(urlParams, HTTP.UTF_8);
         }
 


### PR DESCRIPTION
I had a go at implementing the event API. It works asynchronous from the other REST calls because synchting is blocking if no events are available. Specific events (currently ItemFinished, FolderCompletion, DeviceConnected, DeviceDiscovered, StateChanged) are converted to broadcast intents with the base URI com.nutomic.syncthingandroid.event. A itemfinished event is sent as a broadcast intent of com.nutomic.syncthingandroid.event.itemfinished. This allows the service to implement a broadcast receiver and act according to the event it got (eg. update the media database, show a message, etc.). More than this, it enables other applications to register for the broadcast intents and act on them (eg. a widget showing the last synced file).

This code is meant as a first try and base for discussion. Some things are currently missing:
- If syncthing is restarted, previous events are lost. Before stopping syncthing remaining events should be processed.
- No tests.
- The broadcast intents must be used and converted into useful actions.
- When restarting syncthing the event processor must be correctly restarted also. Currently this is not always working.

Before I go any further I'd like to know what you think about this idea. Is converting the events into broadcast intents a way to implement this or does it collide with your design ideas for this app?