### PR TITLE
Fix "Wifi only" / "Charging only" not being applied immediately

### DIFF
--- a/src/main/java/com/nutomic/syncthingandroid/fragments/SettingsFragment.java
+++ b/src/main/java/com/nutomic/syncthingandroid/fragments/SettingsFragment.java
@@ -227,9 +227,7 @@ public class SettingsFragment extends PreferenceFragment
 
         boolean requireRestart = false;
 
-        if (preference.equals(mSyncOnlyCharging) || preference.equals(mSyncOnlyWifi)) {
-            mSyncthingService.updateState();
-        } else if (preference.equals(mAlwaysRunInBackground)) {
+        if (preference.equals(mAlwaysRunInBackground)) {
             boolean value = (Boolean) o;
             preference.setSummary((value)
                     ? R.string.always_run_in_background_enabled

--- a/src/main/java/com/nutomic/syncthingandroid/syncthing/SyncthingService.java
+++ b/src/main/java/com/nutomic/syncthingandroid/syncthing/SyncthingService.java
@@ -268,6 +268,8 @@ public class SyncthingService extends Service implements
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
         if (key.equals(PREF_NOTIFICATION_TYPE))
             updateNotification();
+        else if (key.equals(PREF_SYNC_ONLY_CHARGING) || key.equals(PREF_SYNC_ONLY_WIFI))
+            updateState();
     }
 
     /**


### PR DESCRIPTION
When turning on the "Sync only on wifi" option while on a mobile network, this may fail, if no other setting that causes a call to `mSyncthingService.updateState()` is also triggered.

The root cause seems to be that [`SettingsFragment`](https://github.com/syncthing/syncthing-android/blob/master/src/main/java/com/nutomic/syncthingandroid/fragments/SettingsFragment.java) line 231 is called in `onPreferenceChange()` which is called _before_ the setting is persisted.

I think, it would be better to remove the call to `mSyncthingService.updateState()` from `SettingsFragment` and enhance `onSharedPreferenceChanged()` directly in the service.