### PR TITLE
Add warning that exported private key may be stored in an unsafe location

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -137,7 +137,7 @@
     <string name="folder_path_required">The folder path must not be empty</string>
 
     <!-- Dialog shown before config export -->
-    <string name="dialog_confirm_export">Do you really want to export your configuration? Existing files will be overwritten.</string>
+    <string name="dialog_confirm_export">Do you really want to export your configuration? Existing files will be overwritten.\n\nWARNING! Other applications may be able to read the private key from the backup location and use it to download/modify synchronized files.</string>
 
     <!-- Dialog shown before config import -->
     <string name="dialog_confirm_import">Do you really want to import a new configuration? Existing files will be overwritten.</string>


### PR DESCRIPTION
The current export functionality stores the unencrypted private Syncthing private key in the backup folder, which is on the shared storage (SD-card or emulated SD card) and can therefore be read by any application on the device and/or when connecting the mobile phone to a PC.

Therefore the user should at least be warned that this might compromise the security of the key.

This pull request adds a warning to the export confirmation dialog in the English translation. Other translations are needed.