### PR TITLE
[WIP] Check if JSON string is null before parsing.

### DIFF
--- a/src/main/java/com/nutomic/syncthingandroid/syncthing/RestApi.java
+++ b/src/main/java/com/nutomic/syncthingandroid/syncthing/RestApi.java
@@ -218,6 +218,9 @@ public class RestApi implements SyncthingService.OnWebGuiAvailableListener,
         new GetTask(mHttpsCertPath) {
             @Override
             protected void onPostExecute(String s) {
+                if (s == null)
+                    return;
+
                 try {
                     JSONObject json = new JSONObject(s);
                     mVersion = json.getString("version");
@@ -986,11 +989,14 @@ public class RestApi implements SyncthingService.OnWebGuiAvailableListener,
     /**
      * Normalizes a given device ID.
      */
-    public void normalizeDeviceId(String id, final OnDeviceIdNormalizedListener listener) {
+    public void normalizeDeviceId(final String id, final OnDeviceIdNormalizedListener listener) {
         new GetTask(mHttpsCertPath) {
             @Override
             protected void onPostExecute(String s) {
                 super.onPostExecute(s);
+                if (s == null)
+                    return;
+
                 String normalized = null;
                 String error = null;
                 try {
@@ -1127,6 +1133,9 @@ public class RestApi implements SyncthingService.OnWebGuiAvailableListener,
             @Override
             protected void onPostExecute(String s) {
                 try {
+                    if (s == null)
+                        return;
+
                     listener.onReceiveUsageReport(new JSONObject(s).toString(4));
                 } catch (JSONException e) {
                     throw new RuntimeException("Failed to prettify usage report", e);


### PR DESCRIPTION
There are lots of crashes like this on Google Play:
```
java.lang.NullPointerException
	at org.json.JSONTokener.nextCleanInternal(JSONTokener.java:116)
	at org.json.JSONTokener.nextValue(JSONTokener.java:94)
	at org.json.JSONObject.<init>(JSONObject.java:154)
	at org.json.JSONObject.<init>(JSONObject.java:171)
	at com.nutomic.syncthingandroid.syncthing.RestApi$9.onPostExecute(RestApi.java:997)
	at com.nutomic.syncthingandroid.syncthing.RestApi$9.onPostExecute(RestApi.java:990)
	at android.os.AsyncTask.finish(AsyncTask.java:631)
	at android.os.AsyncTask.access$600(AsyncTask.java:177)
	at android.os.AsyncTask$InternalHandler.handleMessage(AsyncTask.java:644)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loop(Looper.java:137)
	at android.app.ActivityThread.main(ActivityThread.java:5473)
	at java.lang.reflect.Method.invokeNative(Native Method)
	at java.lang.reflect.Method.invoke(Method.java:525)
	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:854)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:670)
	at dalvik.system.NativeStart.main(Native Method)
```

I added null checks in most places except [this one](https://github.com/syncthing/syncthing-android/blob/master/src/main/java/com/nutomic/syncthingandroid/syncthing/RestApi.java#L236). I'm not sure what to do there, because the app won't work without a config. Maybe we should try even more times, or force an app restart or something? Or show a message to the user? It would be helpful to know why these calls fail in the first place.