### PR TITLE
Fix NullPointerException in onNewIntent()

### DIFF
--- a/src/main/java/com/nutomic/syncthingandroid/activities/MainActivity.java
+++ b/src/main/java/com/nutomic/syncthingandroid/activities/MainActivity.java
@@ -284,6 +284,10 @@ public class MainActivity extends SyncthingActivity
     protected void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
 
+        // intent's action will be null if notification is selected
+        if (intent.getAction() == null) {
+            return;
+        }
         switch (intent.getAction()) {
             case ACTION_ADD_DEVICE:
                 final String deviceId = intent.getStringExtra(EXTRA_DEVICE_ID);


### PR DESCRIPTION
An implementation for `onNewIntent` has been added in c28065786, but doesn't take into consideration that the notification will also send an intent, but without an action. So need to add a `null` check.