### PR TITLE
Experimental setting to keep a partial wakelock

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <application
         android:allowBackup="false"

--- a/src/main/java/com/nutomic/syncthingandroid/fragments/SettingsFragment.java
+++ b/src/main/java/com/nutomic/syncthingandroid/fragments/SettingsFragment.java
@@ -58,6 +58,7 @@ public class SettingsFragment extends PreferenceFragment
     private CheckBoxPreference mSyncOnlyWifi;
     private WifiSsidPreference mSyncOnlyOnSSIDs;
     private CheckBoxPreference mUseRoot;
+    private CheckBoxPreference mKeepWakelock;
     private PreferenceScreen mOptionsScreen;
     private PreferenceScreen mGuiScreen;
     private SyncthingService mSyncthingService;
@@ -134,6 +135,7 @@ public class SettingsFragment extends PreferenceFragment
         mSyncOnlyOnSSIDs = (WifiSsidPreference) findPreference(SyncthingService.PREF_SYNC_ONLY_WIFI_SSIDS);
         mSyncOnlyOnSSIDs.setDefaultValue(new TreeSet<String>()); // default to empty list
         mUseRoot = (CheckBoxPreference) findPreference(SyncthingService.PREF_USE_ROOT);
+        mKeepWakelock = (CheckBoxPreference) findPreference(SyncthingService.PREF_USE_WAKE_LOCK);
         Preference appVersion = screen.findPreference(APP_VERSION_KEY);
         mOptionsScreen = (PreferenceScreen) screen.findPreference(SYNCTHING_OPTIONS_KEY);
         mGuiScreen = (PreferenceScreen) screen.findPreference(SYNCTHING_GUI_KEY);
@@ -153,6 +155,7 @@ public class SettingsFragment extends PreferenceFragment
         mSyncOnlyWifi.setOnPreferenceChangeListener(this);
         mSyncOnlyOnSSIDs.setOnPreferenceChangeListener(this);
         mUseRoot.setOnPreferenceClickListener(this);
+        mKeepWakelock.setOnPreferenceClickListener(this);
         screen.findPreference(EXPORT_CONFIG).setOnPreferenceClickListener(this);
         screen.findPreference(IMPORT_CONFIG).setOnPreferenceClickListener(this);
         screen.findPreference(SYNCTHING_RESET).setOnPreferenceClickListener(this);
@@ -357,6 +360,9 @@ public class SettingsFragment extends PreferenceFragment
                     new Thread(new ChownFilesRunnable()).start();
                     mSyncthingService.getApi().requireRestart(getActivity());
                 }
+                return true;
+            case SyncthingService.PREF_USE_WAKE_LOCK:
+                mSyncthingService.getApi().requireRestart(getActivity());
                 return true;
             case EXPORT_CONFIG:
                 new AlertDialog.Builder(getActivity())

--- a/src/main/java/com/nutomic/syncthingandroid/syncthing/SyncthingService.java
+++ b/src/main/java/com/nutomic/syncthingandroid/syncthing/SyncthingService.java
@@ -94,6 +94,7 @@ public class SyncthingService extends Service implements
     public static final String PREF_SYNC_ONLY_CHARGING       = "sync_only_charging";
     public static final String PREF_USE_ROOT                 = "use_root";
     private static final String PREF_NOTIFICATION_TYPE       = "notification_type";
+    public static final String PREF_USE_WAKE_LOCK            = "wakelock_while_binary_running";
 
     private static final int NOTIFICATION_ACTIVE = 1;
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -296,6 +296,12 @@ Please report any problems you encounter via Github.</string>
 
     <string name="export_config">Export Configuration</string>
 
+    <string name="experimental_settings">Experimental</string>
+
+    <string name="keep_wakelock_while_binary_running">Keep the CPU awake while Syncthing is running</string>
+
+    <string name="keep_wakelock_while_binary_running_summary">Use this setting if you experience unexpected disconnects while operating on battery. This will result in increased battery consumption.</string>
+
     <!-- Toast shown after config was successfully exported -->
     <string name="config_export_successful">Config was exported to %1$s</string>
 

--- a/src/main/res/xml/app_settings.xml
+++ b/src/main/res/xml/app_settings.xml
@@ -147,6 +147,18 @@
             android:title="@string/streset_title"
             android:singleLine="true" />
 
+        <PreferenceScreen
+            android:key="syncthing_experimental"
+            android:title="@string/experimental_settings">
+
+            <CheckBoxPreference
+                android:key="wakelock_while_binary_running"
+                android:title="@string/keep_wakelock_while_binary_running"
+                android:summary="@string/keep_wakelock_while_binary_running_summary"
+                android:defaultValue="false" />
+
+        </PreferenceScreen>
+
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
Issues like #498 and #515 might be caused by the CPU going to sleep if not connected to a power-supply. In Android, for the CPU to remain active after screen has turned off, it is necessary to keep a [partial wake-lock][1]. 

Current discussion in the issues mentioned above indicates, that the native binary is not aware of this and does not hold any wake-locks and might crash if there is a time-jump forward (which will be the case if CPU goes to sleep for some undefined time). Also for other devices this will be seen as a disconnect, even if the binary does not crash.

This PR adds an "Experimental" section to the settings that allows to enable holding a partial wake-lock while the binary is running.

This PR does not yet address Android 6 usability for handling [App Standby and Doze][2] mode.

[1]: http://developer.android.com/reference/android/os/PowerManager.html#PARTIAL_WAKE_LOCK
[2]: http://developer.android.com/training/monitoring-device-state/doze-standby.html#support_for_other_use_cases