### PR TITLE
Code quality fix - Classes and methods that rely on the default system encoding should not be used. 

### DIFF
--- a/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
+++ b/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
@@ -135,7 +135,7 @@ public class LogActivity extends SyncthingActivity {
             pb.redirectErrorStream(true);
             process = pb.start();
             BufferedReader bufferedReader = new BufferedReader(
-                    new InputStreamReader(process.getInputStream()), 8192);
+                    new InputStreamReader(process.getInputStream(), "UTF-8"), 8192);
             StringBuilder log = new StringBuilder();
             String line = "";
             String sep = System.getProperty("line.separator");

--- a/src/main/java/com/nutomic/syncthingandroid/syncthing/GetTask.java
+++ b/src/main/java/com/nutomic/syncthingandroid/syncthing/GetTask.java
@@ -80,7 +80,7 @@ public class GetTask extends AsyncTask<String, Void, String> {
                 if (entity != null) {
                     InputStream is = entity.getContent();
 
-                    BufferedReader br = new BufferedReader(new InputStreamReader(is));
+                    BufferedReader br = new BufferedReader(new InputStreamReader(is, "UTF-8"));
                     String line;
                     String result = "";
                     while ((line = br.readLine()) != null) {

--- a/src/main/java/com/nutomic/syncthingandroid/syncthing/SyncthingRunnable.java
+++ b/src/main/java/com/nutomic/syncthingandroid/syncthing/SyncthingRunnable.java
@@ -242,7 +242,7 @@ public class SyncthingRunnable implements Runnable {
                 psOut.writeBytes("exit\n");
                 psOut.flush();
                 ps.waitFor();
-                InputStreamReader isr = new InputStreamReader(ps.getInputStream());
+                InputStreamReader isr = new InputStreamReader(ps.getInputStream(), "UTF-8");
                 BufferedReader br = new BufferedReader(isr);
                 String id;
                 while ((id = br.readLine()) != null) {
@@ -312,7 +312,7 @@ public class SyncthingRunnable implements Runnable {
             @Override
             public void run() {
                 try {
-                    InputStreamReader isr = new InputStreamReader(is);
+                    InputStreamReader isr = new InputStreamReader(is, "UTF-8");
                     BufferedReader br = new BufferedReader(isr);
                     String line;
                     while ((line = br.readLine()) != null) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1943 - Classes and methods that rely on the default system encoding should not be used. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1943
 
Please let me know if you have any questions.

Faisal Hameed