### PR TITLE
Code quality fix - Useless parentheses around expressions should be removed to prevent any misunderstanding.

### DIFF
--- a/src/main/java/com/nutomic/syncthingandroid/fragments/DeviceFragment.java
+++ b/src/main/java/com/nutomic/syncthingandroid/fragments/DeviceFragment.java
@@ -289,7 +289,7 @@ public class DeviceFragment extends Fragment implements
     private void updateViewsAndSetListeners() {
         // Update views
         mIdView.setText(mDevice.deviceID);
-        mNameView.setText((mDevice.name));
+        mNameView.setText(mDevice.name);
         mAddressesView.setText(displayableAddresses());
         mCompressionValueView.setText(Compression.fromValue(getActivity(), mDevice.compression).getTitle(getActivity()));
         mIntroducerView.setChecked(mDevice.introducer);

--- a/src/main/java/com/nutomic/syncthingandroid/syncthing/NetworkReceiver.java
+++ b/src/main/java/com/nutomic/syncthingandroid/syncthing/NetworkReceiver.java
@@ -22,7 +22,7 @@ public class NetworkReceiver extends BroadcastReceiver {
         ConnectivityManager cm =
                 (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
         NetworkInfo wifiInfo = cm.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
-        boolean isWifiConnected = (wifiInfo != null && wifiInfo.isConnected());
+        boolean isWifiConnected = wifiInfo != null && wifiInfo.isConnected();
         Log.v(TAG, "Received wifi " + (isWifiConnected ? "connected" : "disconnected") + " event");
         Intent i = new Intent(context, SyncthingService.class);
         i.putExtra(DeviceStateHolder.EXTRA_HAS_WIFI, isWifiConnected);

--- a/src/main/java/com/nutomic/syncthingandroid/util/FoldersAdapter.java
+++ b/src/main/java/com/nutomic/syncthingandroid/util/FoldersAdapter.java
@@ -59,7 +59,7 @@ public class FoldersAdapter extends ArrayAdapter<RestApi.Folder>
         RestApi.Model model = mModels.get(folder.id);
         id.setText(folder.id);
         state.setTextColor(getContext().getResources().getColor(R.color.text_green));
-        directory.setText((folder.path));
+        directory.setText(folder.path);
         if (model != null) {
             int percentage = (model.globalBytes != 0)
                     ? Math.round(100 * model.inSyncBytes / model.globalBytes)


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck

Please let me know if you have any questions.

Faisal Hameed