### PR TITLE
Add Broadcast-Receiver to remotely control the app (Addresses also #460)

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -91,6 +91,11 @@
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
             </intent-filter>
         </receiver>
+        <receiver android:name=".syncthing.AppConfigReceiver">
+            <intent-filter>
+                <action android:name="com.nutomic.syncthingandroid.APP_CONFIGURE" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/src/main/java/com/nutomic/syncthingandroid/syncthing/AppConfigReceiver.java
+++ b/src/main/java/com/nutomic/syncthingandroid/syncthing/AppConfigReceiver.java
@@ -1,0 +1,29 @@
+package com.nutomic.syncthingandroid.syncthing;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+
+/**
+ *
+ * Created by sqrt-1764 on 25.03.16.
+ */
+public class AppConfigReceiver extends BroadcastReceiver {
+    public static final String ACTION_QUIT_SYNCTHING = "quit";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        final Bundle extras = intent.getExtras();
+
+        if (extras == null) return;
+
+        for (String key : extras.keySet()) {
+            switch (key) {
+                case ACTION_QUIT_SYNCTHING:
+                    context.stopService(new Intent(context, SyncthingService.class));
+                    break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
In order to not have to reinvent the wheel, SyncThing should be controllable by some intents.
I also need an option to save battery and need SyncThing running only at certain places / times.

We have tools like Tasker, Llama or Automate to customize our device. So the user-logic can be implemented by the users if SyncThing is remotely configurable.

A implemented a quick and simple solution:
Added a IntentService to receive Broadcast-Intents to remotely control / configure the app.

As a first step only the "quit"-command is implemented in this service.
It simply stops the SyncThingService.

TODO (?): Also kill a bound activity if any. At the moment, if the activity is active (bound to the service), the service is stopped only after the activity is left.
Before putting work into this I want to make shure that my solution is a step into the right direction. ;-)