### PR TITLE
Add checks for null-SSID (fix for #620)

### DIFF
--- a/src/main/java/com/nutomic/syncthingandroid/preferences/WifiSsidPreference.java
+++ b/src/main/java/com/nutomic/syncthingandroid/preferences/WifiSsidPreference.java
@@ -91,11 +91,13 @@ public class WifiSsidPreference extends MultiSelectListPreference {
     private CharSequence[] extractSsid(WifiConfiguration[] configs, boolean stripQuotes) {
         CharSequence[] result = new CharSequence[configs.length];
         for (int i = 0; i < configs.length; i++) {
+            // See #620: there may be null-SSIDs
+            String ssid = configs[i].SSID != null ? configs[i].SSID : "";
             // WiFi SSIDs can either be UTF-8 (encapsulated in '"') or hex-strings
             if (stripQuotes)
-                result[i] = configs[i].SSID.replaceFirst("^\"", "").replaceFirst("\"$", "");
+                result[i] = ssid.replaceFirst("^\"", "").replaceFirst("\"$", "");
             else
-                result[i] = configs[i].SSID;
+                result[i] = ssid;
         }
         return result;
     }
@@ -115,7 +117,10 @@ public class WifiSsidPreference extends MultiSelectListPreference {
                 Arrays.sort(result, new Comparator<WifiConfiguration>() {
                     @Override
                     public int compare(WifiConfiguration lhs, WifiConfiguration rhs) {
-                        return lhs.SSID.compareToIgnoreCase(rhs.SSID);
+                        // See #620: There may be null-SSIDs
+                        String l = lhs.SSID != null ? lhs.SSID : "";
+                        String r = rhs.SSID != null ? rhs.SSID : "";
+                        return l.compareToIgnoreCase(r);
                     }
                 });
                 return result;


### PR DESCRIPTION
This is a simple safety check for null when accessing and displaying SSIDs in `WifiSsidPreference`. I still think that there is something going on inside CM regarding maybe missing permissions, because I cannot think of a valid case where a stored WiFi network has no SSID.

The check in `SyncthingService` is already null-safe.