### PR TITLE
fixes RestApi options for 'listenAddress'

### DIFF
--- a/src/main/res/xml/app_settings.xml
+++ b/src/main/res/xml/app_settings.xml
@@ -53,7 +53,7 @@
                 android:inputType="textCapWords" />
 
             <EditTextPreference
-                android:key="listenAddress"
+                android:key="listenAddresses"
                 android:title="@string/listen_address"
                 android:persistent="false"
                 android:inputType="textNoSuggestions" />
@@ -85,7 +85,7 @@
             <CheckBoxPreference
                 android:key="upnpEnabled"
                 android:title="@string/upnp_enabled"
-                android:persistent="false" />
+                android:persistent="false"/>
 
             <EditTextPreference
                 android:key="globalAnnounceServers"


### PR DESCRIPTION
this fixes display of syncthing listenAddress(es) in options menu. 