### PR TITLE
Experimental "Run as foreground service" setting

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -298,6 +298,10 @@ Please report any problems you encounter via Github.</string>
 
     <string name="keep_wakelock_while_binary_running_summary">Use this setting if you experience unexpected disconnects while operating on battery. This will result in increased battery consumption.</string>
 
+    <string name="run_as_foreground_service">Run service with foreground priority</string>
+
+    <string name="run_as_foreground_service_summary">If enabled, Syncthing will run with foreground priority and is less likely to be stopped by Android. This might cause other services to be stopped if available memory is low.</string>
+
     <!-- Toast shown after config was successfully exported -->
     <string name="config_export_successful">Config was exported to %1$s</string>
 
@@ -416,6 +420,8 @@ Please report any problems you encounter via Github.</string>
 
     <!-- Title of the notification shown while syncthing is running and enabled -->
     <string name="syncthing_active">Syncthing is running</string>
+
+    <string name="syncthing_active_foreground">Service is running with foreground priority.</string>
 
     <!-- Toast shown if folder observer fails to traverse a folder -->
     <string name="toast_folder_observer_stack_overflow">Directory tree too deep. Check for cyclic symlinks</string>

--- a/src/main/res/xml/app_settings.xml
+++ b/src/main/res/xml/app_settings.xml
@@ -162,6 +162,12 @@
                 android:summary="@string/keep_wakelock_while_binary_running_summary"
                 android:defaultValue="false" />
 
+            <CheckBoxPreference
+                android:key="run_as_foreground_service"
+                android:title="@string/run_as_foreground_service"
+                android:summary="@string/run_as_foreground_service_summary"
+                android:defaultValue="false" />
+
         </PreferenceScreen>
 
     </PreferenceCategory>


### PR DESCRIPTION
This PR adds a setting to have the service running with `startForeground()` as a setting in the "Experimental" section.

On my OnePlus 2, the background service gets killed after 5-10 minutes of high activity (i.e. when transferring many/large files) due to a custom addition to `ActivityManager` called `BgDetect`.

    07-06 20:52:26.562  1181  1363 I ActivityManager: [BgDetect]chkExcessCpu doKills: true uptime: 300309
    07-06 20:52:26.960  1181  1363 I ActivityManager: [BgDetect]detect excessive cpu on forked process libsyncthing.so(pid : 2758) plan to stop it 371060 during 300309
    07-06 20:52:26.960  1181  1363 I ActivityManager: [BgDetect]force stop com.nutomic.syncthingandroid.debug (uid 10132)
    07-06 20:52:26.965  1181  1363 I ActivityManager: Force stopping com.nutomic.syncthingandroid.debug appid=10132 user=0: from pid 1181
    07-06 20:52:26.966  1181  1363 I ActivityManager: Killing 1360:com.nutomic.syncthingandroid.debug/u0a132 (adj 15): stop com.nutomic.syncthingandroid.debug
    07-06 20:52:26.968  1181  1363 W ActivityManager: Scheduling restart of crashed service com.nutomic.syncthingandroid.debug/com.nutomic.syncthingandroid.syncthing.SyncthingService in 1000ms
    07-06 20:52:26.968  1181  1354 V ActivityManager: killProcessGroupAsync took 1 ms for PID 1360 on thread 14
    07-06 20:52:26.971  1181  6410 I libprocessgroup: Killing pid 2758 in uid 10132 as part of process group 1360
    07-06 20:52:26.973  1181  6410 I libprocessgroup: Killing pid 2758 in uid 10132 as part of process group 1360
    07-06 20:52:26.974  1181  1363 I ActivityManager:   Force stopping service ServiceRecord{47304c8 u0 com.nutomic.syncthingandroid.debug/com.nutomic.syncthingandroid.syncthing.SyncthingService}

The only workaround for now is to have it running with foreground priority. This proved to be stable in my experiments and solved the issue on my ROM. Similar issues might affect other ROMs and could be part of the reason for e.g. #634 and similar issues caused by not-running / crashed services.