### PR TITLE
[WIP] Updated Syncthing to v0.14.2

### DIFF
--- a/src/main/java/com/nutomic/syncthingandroid/syncthing/SyncthingRunnable.java
+++ b/src/main/java/com/nutomic/syncthingandroid/syncthing/SyncthingRunnable.java
@@ -117,6 +117,9 @@ public class SyncthingRunnable implements Runnable {
             Map<String, String> env = pb.environment();
             // Set home directory to data folder for web GUI folder picker.
             env.put("HOME", Environment.getExternalStorageDirectory().getAbsolutePath());
+            // workaround for #706 (building the binary with arm/linux instead of arm/android)
+            Log.d(TAG, "Using " + mContext.getCacheDir().getAbsolutePath() + " as TMPDIR");
+            env.put("TMPDIR", mContext.getCacheDir().getAbsolutePath());
             env.put("STTRACE", sp.getString("sttrace", ""));
             env.put("STNORESTART", "1");
             env.put("STNOUPGRADE", "1");


### PR DESCRIPTION
I have updated the Syncthing binary to 0.14.2, since 0.14.1 introduces the delta-index feature, which could be a huge game-changer for mobile users.

Unfortunately, the first run showed that our build-process builds for `linux` and not for `android`, causing a crash, since the delta-index feature requires a temporary directory. (See also #706).

I have added the `TMPDIR` environment variable, pointed it to the application's "cache" directory, this seems to be working quite well.

Still I'd like someone else to have a look before merging this on the official repository.