### PR TITLE
Disable sync if Android sync setting is disabled

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.READ_SYNC_SETTINGS" />
 
     <application
         android:allowBackup="false"

--- a/src/main/java/com/nutomic/syncthingandroid/syncthing/DeviceStateHolder.java
+++ b/src/main/java/com/nutomic/syncthingandroid/syncthing/DeviceStateHolder.java
@@ -2,6 +2,7 @@ package com.nutomic.syncthingandroid.syncthing;
 
 import android.annotation.TargetApi;
 import android.content.BroadcastReceiver;
+import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -103,9 +104,14 @@ public class DeviceStateHolder extends BroadcastReceiver {
         return mWifiSsid;
     }
 
+    /**
+     * Determines if Syncthing should currently run.
+     */
     public boolean shouldRun() {
-        if (SyncthingService.alwaysRunInBackground(mContext)) {
-            // Always run, ignoring wifi/charging state.
+        if (!ContentResolver.getMasterSyncAutomatically()) {
+            return false;
+        }
+        else if (SyncthingService.alwaysRunInBackground(mContext)) {
             return true;
         }
         else {

--- a/src/main/java/com/nutomic/syncthingandroid/syncthing/SyncthingService.java
+++ b/src/main/java/com/nutomic/syncthingandroid/syncthing/SyncthingService.java
@@ -1,8 +1,10 @@
 package com.nutomic.syncthingandroid.syncthing;
 
+import android.annotation.TargetApi;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.app.Service;
+import android.content.BroadcastReceiver;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
@@ -13,6 +15,7 @@ import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Environment;
 import android.os.IBinder;
+import android.os.PowerManager;
 import android.preference.PreferenceManager;
 import android.support.v4.app.NotificationCompat;
 import android.util.Log;
@@ -129,6 +132,13 @@ public class SyncthingService extends Service implements
     private final SyncStatusObserver mSyncStatusObserver = new SyncStatusObserver() {
         @Override
         public void onStatusChanged(int i) {
+            updateState();
+        }
+    };
+
+    private final BroadcastReceiver mPowerSaveModeChangedReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
             updateState();
         }
     };
@@ -301,6 +311,7 @@ public class SyncthingService extends Service implements
      * Starts the native binary.
      */
     @Override
+    @TargetApi(21)
     public void onCreate() {
         PRNGFixes.apply();
         SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(this);
@@ -321,6 +332,11 @@ public class SyncthingService extends Service implements
 
         mDeviceStateHolder = new DeviceStateHolder(SyncthingService.this);
         registerReceiver(mDeviceStateHolder, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.HONEYCOMB) {
+            registerReceiver(mPowerSaveModeChangedReceiver,
+                    new IntentFilter(PowerManager.ACTION_POWER_SAVE_MODE_CHANGED));
+        }
+
         new StartupTask(sp.getString("gui_user",""), sp.getString("gui_password","")).execute();
         sp.registerOnSharedPreferenceChangeListener(this);
         ContentResolver.addStatusChangeListener(ContentResolver.SYNC_OBSERVER_TYPE_SETTINGS,
@@ -432,6 +448,8 @@ public class SyncthingService extends Service implements
         SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(this);
         sp.unregisterOnSharedPreferenceChangeListener(this);
         ContentResolver.removeStatusChangeListener(mSyncStatusObserver);
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.HONEYCOMB)
+            unregisterReceiver(mPowerSaveModeChangedReceiver);
     }
 
     private void shutdown() {


### PR DESCRIPTION
This is completely untested at the moment.

Also, should we add a preference whether to consider the master sync setting?