### PR TITLE
Log SSID whitelist for better troubleshooting of #700

### DIFF
--- a/src/main/java/com/nutomic/syncthingandroid/syncthing/SyncthingService.java
+++ b/src/main/java/com/nutomic/syncthingandroid/syncthing/SyncthingService.java
@@ -269,10 +269,10 @@ public class SyncthingService extends Service implements
                 String ssid = mDeviceStateHolder.getWifiSsid();
                 if (ssid != null) {
                     if (ssids.contains(ssid)) {
-                        Log.d(TAG, "SSID " + ssid + " found in whitelist");
+                        Log.d(TAG, "SSID [" + ssid + "] found in whitelist: " + ssids);
                         return true;
                     }
-                    Log.i(TAG, "SSID " + ssid + " not whitelisted");
+                    Log.i(TAG, "SSID [" + ssid + "] not whitelisted: " + ssids);
                     return false;
                 } else {
                     // Don't know the SSID (yet) (should not happen?!), so not allowing


### PR DESCRIPTION
To better diagnose issue #700, log the whitelist alongside the connected SSID when `isAllowedWifiConnected` is not connected.