### PR TITLE
Explain requirement for notification in "Run as foreground" setting (fixes #715)

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -302,7 +302,7 @@ Please report any problems you encounter via Github.</string>
 
     <string name="run_as_foreground_service">Run service with foreground priority</string>
 
-    <string name="run_as_foreground_service_summary">If enabled, Syncthing will run with foreground priority and is less likely to be stopped by Android. This might cause other services to be stopped if available memory is low.</string>
+    <string name="run_as_foreground_service_summary">If enabled, Syncthing will run with foreground priority and is less likely to be stopped by Android. This might cause other services to be stopped if available memory is low. A low-priority notification needs to be shown due to Android requirements, regardless of the \"Notification\" setting.</string>
 
     <!-- Toast shown after config was successfully exported -->
     <string name="config_export_successful">Config was exported to %1$s</string>


### PR DESCRIPTION
Add suggested explanation of #715 to `run_as_foreground_service_summary`.