### PR TITLE
Set STGUIASSETS to let user add custom themes without root

### DIFF
--- a/src/main/java/com/nutomic/syncthingandroid/syncthing/SyncthingRunnable.java
+++ b/src/main/java/com/nutomic/syncthingandroid/syncthing/SyncthingRunnable.java
@@ -118,6 +118,7 @@ public class SyncthingRunnable implements Runnable {
             // Set home directory to data folder for web GUI folder picker.
             env.put("HOME", Environment.getExternalStorageDirectory().getAbsolutePath());
             env.put("STTRACE", sp.getString("sttrace", ""));
+            env.put("STGUIASSETS", getExternalFilesDir(null).getAbsolutePath() + "/gui");
             env.put("STNORESTART", "1");
             env.put("STNOUPGRADE", "1");
             if (sp.getBoolean("use_tor", false)) {


### PR DESCRIPTION
Set the STGUIASSETS env var to primary storage  (e.g. `/storage/emulated/0/Android/data/com.nutomic.syncthingandroid/gui`) to be able to add custom themes.

As I am not very fond of the new dark / gray theme (especially on an OLED display), I would like to add the old dark theme, which isn't possible on Android at the moment (without root).

This should fix that.

The path defaults to $STHOME/gui and Syncthing has no problem if that doesn't exist, so there should be no problem here either. That's also why I don't think there should be a setting for that.

I'm not an Android dev and have no Android dev environment to test this, but from what I read, it should work as expected ;)