### PR TITLE
Stop screen rotation from redrawing activity.  (fix #805 , #807 & #804)

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -40,7 +40,9 @@
         <activity
             android:name=".activities.MainActivity"
             android:label="@string/app_name"
-            android:launchMode="singleTop">
+            android:launchMode="singleTop"
+            android:configChanges="orientation|screenSize"
+            >
         </activity>
         <activity
             android:name=".activities.WebGuiActivity"

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -75,13 +75,17 @@
             android:theme="@style/Theme.Syncthing.Translucent"
             android:launchMode="singleTop"/>
         <activity android:name=".activities.DeviceActivity"
-            android:parentActivityName=".activities.MainActivity">
+            android:parentActivityName=".activities.MainActivity"
+            android:configChanges="orientation|screenSize"
+            >
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".activities.MainActivity" />
         </activity>
         <activity android:name=".activities.FolderActivity"
-            android:parentActivityName=".activities.MainActivity">
+            android:parentActivityName=".activities.MainActivity"
+            android:configChanges="orientation|screenSize"
+            >
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".activities.MainActivity" />

--- a/src/main/play/en-GB/whatsnew
+++ b/src/main/play/en-GB/whatsnew
@@ -1,7 +1,0 @@
-- sort folders and devices (@nutomic)
-- change default compression to metadata only (@nutomic)
-- fixed chmod problem with syncthing binary (@zillode)
-- fixed dialog background on pre-Lollipop (@veniosg)
-- various design improvements (@veniosg)
-- imported translations
-- updated syncthing to v0.11.22


### PR DESCRIPTION
The changes to the manifest tell android that we want to handle screen changes and hence the activity if not recreated apon rotating the screen. The same goes for the folder and device activities. (fix #805 , #80  7 & #804)