### PR TITLE
Fix DNS resolution on IPv6 networks/resolvers

### DIFF
--- a/patches/golang/all/dns.patch
+++ b/patches/golang/all/dns.patch
@@ -27,7 +27,7 @@
 +		}
 +		output := strings.Trim(string(outputBytes), "\n")
 +		if ParseIP(output) != nil {
-+			servers = append(servers, output + ":53")
++			servers = append(servers, JoinHostPort(output, "53"))
 +		}
 +	}
 +


### PR DESCRIPTION
With IPv6, you must never just append ":port" to a possible IP, as for
IPv6 it must be wrapped in brackets, e.g. [::1]:53

This should fix #817