### PR TITLE
Fix missing path separator in folder copy target

### DIFF
--- a/src/main/java/com/nutomic/syncthingandroid/activities/ShareActivity.java
+++ b/src/main/java/com/nutomic/syncthingandroid/activities/ShareActivity.java
@@ -228,7 +228,7 @@ public class ShareActivity extends SyncthingActivity
             boolean isError = false;
             for (Map.Entry<Uri, String> entry : mFiles.entrySet()) {
                 InputStream inputStream = null;
-                String outPath = mFolder.path + entry.getValue();
+                String outPath = mFolder.path + "/" + entry.getValue();
                 try {
                     File outFile = new File(outPath);
                     if (outFile.isFile()) {

--- a/src/main/java/com/nutomic/syncthingandroid/activities/ShareActivity.java
+++ b/src/main/java/com/nutomic/syncthingandroid/activities/ShareActivity.java
@@ -228,9 +228,8 @@ public class ShareActivity extends SyncthingActivity
             boolean isError = false;
             for (Map.Entry<Uri, String> entry : mFiles.entrySet()) {
                 InputStream inputStream = null;
-                String outPath = mFolder.path + "/" + entry.getValue();
                 try {
-                    File outFile = new File(outPath);
+                    File outFile = new File(mFolder.path, entry.getValue());
                     if (outFile.isFile()) {
                         mIgnored++;
                         continue;


### PR DESCRIPTION
When a file is shared to the application, the destination path is missing a trailing / (as tested by out of the box use with the GUI to create and share a folder). So, when a file is copied in to a share directory (example /sdcard/Sync), the file is copied instead to "/sdcard/Sync${SOURCEFILENAME}" instead of "/sdcard/Sync/${SOURCEFILENAME}".