### PR TITLE
Stopped dialogs from losing state after screen rotation Fixes for: #804 #805 #807.

### DIFF
--- a/src/main/java/com/nutomic/syncthingandroid/activities/DeviceActivity.java
+++ b/src/main/java/com/nutomic/syncthingandroid/activities/DeviceActivity.java
@@ -55,12 +55,9 @@ public class DeviceActivity extends SyncthingActivity implements View.OnClickLis
             "com.nutomic.syncthingandroid.activities.DeviceActivity.IS_CREATE";
 
     private static final String TAG = "DeviceSettingsFragment";
-    private static final String IS_SHOWING_DISCARD_DIALOG =
-            "com.nutomic.syncthingandroid.activities.DeviceActivity.DISCARD_FOLDER_DIALOG_STATE";
-    private static final String IS_SHOWING_COMPRESSION_DIALOG =
-            "com.nutomic.syncthingandroid.activities.DeviceActivity.COMPRESSION_FOLDER_DIALOG_STATE";
-    private static final String IS_SHOWING_DELETE_DIALOG =
-            "com.nutomic.syncthingandroid.activities.DeviceActivity.DELETE_FOLDER_DIALOG_STATE";
+    private static final String IS_SHOWING_DISCARD_DIALOG = "DISCARD_FOLDER_DIALOG_STATE";
+    private static final String IS_SHOWING_COMPRESSION_DIALOG = "COMPRESSION_FOLDER_DIALOG_STATE";
+    private static final String IS_SHOWING_DELETE_DIALOG = "DELETE_FOLDER_DIALOG_STATE";
 
     public static final List<String> DYNAMIC_ADDRESS = Collections.singletonList("dynamic");
 
@@ -90,21 +87,14 @@ public class DeviceActivity extends SyncthingActivity implements View.OnClickLis
 
     private boolean mDeviceNeedsToUpdate;
 
-    private boolean mIsShowingDiscardDialog;
-    private boolean mIsShowingCompressionDialog;
-    private boolean mIsShowingDeleteDialog;
-
     private Dialog mDeleteDialog;
     private Dialog mDiscardDialog;
     private Dialog mCompressionDialog;
-
-
 
     private final DialogInterface.OnClickListener mCompressionEntrySelectedListener = new DialogInterface.OnClickListener() {
         @Override
         public void onClick(DialogInterface dialog, int which) {
             dialog.dismiss();
-            mIsShowingCompressionDialog = false;
             Compression compression = Compression.fromIndex(which);
             // Don't pop the restart dialog unless the value is actually different.
             if (compression != Compression.fromValue(DeviceActivity.this, mDevice.compression)) {
@@ -189,8 +179,6 @@ public class DeviceActivity extends SyncthingActivity implements View.OnClickLis
             }
             restoreDialogStates(savedInstanceState);
         }
-
-
         if (mIsCreateMode) {
            if (mDevice == null) {
                 initDevice();
@@ -198,24 +186,20 @@ public class DeviceActivity extends SyncthingActivity implements View.OnClickLis
         }
         else {
             prepareEditMode();
-
         }
-
     }
 
     private void restoreDialogStates(Bundle savedInstanceState) {
-        mIsShowingCompressionDialog = savedInstanceState.getBoolean(IS_SHOWING_COMPRESSION_DIALOG);
-        if (mIsShowingCompressionDialog){
+        if (savedInstanceState.getBoolean(IS_SHOWING_COMPRESSION_DIALOG)){
             showCompressionDialog();
         }
-        mIsShowingDeleteDialog = savedInstanceState.getBoolean(IS_SHOWING_DELETE_DIALOG);
-        if (mIsShowingDeleteDialog){
+
+        if (savedInstanceState.getBoolean(IS_SHOWING_DELETE_DIALOG)){
             showDeleteDialog();
         }
 
         if (mIsCreateMode){
-            mIsShowingDiscardDialog = savedInstanceState.getBoolean(IS_SHOWING_DISCARD_DIALOG);
-            if (mIsShowingDiscardDialog){
+            if (savedInstanceState.getBoolean(IS_SHOWING_DISCARD_DIALOG)){
                 showDiscardDialog();
             }
         }
@@ -251,20 +235,18 @@ public class DeviceActivity extends SyncthingActivity implements View.OnClickLis
         super.onSaveInstanceState(outState);
         outState.putString("device", new Gson().toJson(mDevice));
         if (mIsCreateMode){
-            outState.putBoolean(IS_SHOWING_DISCARD_DIALOG, mIsShowingDiscardDialog);
+            outState.putBoolean(IS_SHOWING_DISCARD_DIALOG, mDiscardDialog != null && mDiscardDialog.isShowing());
             if(mDiscardDialog != null){
                 mDiscardDialog.cancel();
             }
         }
 
-        outState.putBoolean(IS_SHOWING_COMPRESSION_DIALOG, mIsShowingCompressionDialog);
+        outState.putBoolean(IS_SHOWING_COMPRESSION_DIALOG, mCompressionDialog != null && mCompressionDialog.isShowing());
         if(mCompressionDialog != null){
             mCompressionDialog.cancel();
         }
 
-
-
-        outState.putBoolean(IS_SHOWING_DELETE_DIALOG, mIsShowingDeleteDialog);
+        outState.putBoolean(IS_SHOWING_DELETE_DIALOG, mDeleteDialog != null && mDeleteDialog.isShowing());
         if (mDeleteDialog != null) {
             mDeleteDialog.cancel();
         }
@@ -375,7 +357,6 @@ public class DeviceActivity extends SyncthingActivity implements View.OnClickLis
 
 
     private void showDeleteDialog(){
-        mIsShowingDeleteDialog = true;
         mDeleteDialog = createDeleteDialog();
         mDeleteDialog.show();
     }
@@ -387,10 +368,8 @@ public class DeviceActivity extends SyncthingActivity implements View.OnClickLis
                     getApi().removeDevice(mDevice.deviceID);
                     finish();
                 })
-                .setNegativeButton(android.R.string.no, (dialog, which) -> mIsShowingDeleteDialog = false)
-                .setOnCancelListener(dialog -> mIsShowingDeleteDialog = false)
+                .setNegativeButton(android.R.string.no, null)
                 .create();
-
     }
 
     /**
@@ -460,7 +439,6 @@ public class DeviceActivity extends SyncthingActivity implements View.OnClickLis
     }
 
     private void showCompressionDialog(){
-        mIsShowingCompressionDialog = true;
         mCompressionDialog = createCompressionDialog();
         mCompressionDialog.show();
     }
@@ -471,7 +449,6 @@ public class DeviceActivity extends SyncthingActivity implements View.OnClickLis
                 .setSingleChoiceItems(R.array.compress_entries,
                         Compression.fromValue(this, mDevice.compression).getIndex(),
                         mCompressionEntrySelectedListener)
-                .setOnCancelListener(dialog -> mIsShowingCompressionDialog = false)
                 .create();
     }
 
@@ -500,15 +477,13 @@ public class DeviceActivity extends SyncthingActivity implements View.OnClickLis
     private void showDiscardDialog(){
         mDiscardDialog = createDiscardDialog();
         mDiscardDialog.show();
-        mIsShowingDiscardDialog = true;
     }
 
     private Dialog createDiscardDialog() {
         return new android.app.AlertDialog.Builder(this)
                 .setMessage(R.string.dialog_discard_changes)
                 .setPositiveButton(android.R.string.ok, (dialog, which) -> finish())
-                .setNegativeButton(android.R.string.cancel, (dialog, which) -> mIsShowingDiscardDialog = false)
-                .setOnCancelListener((dialog -> mIsShowingDiscardDialog = false))
+                .setNegativeButton(android.R.string.cancel, null)
                 .create();
     }
 }

--- a/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
+++ b/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
@@ -2,6 +2,8 @@ package com.nutomic.syncthingandroid.activities;
 
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.app.Dialog;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
@@ -56,11 +58,16 @@ public class FolderActivity extends SyncthingActivity
     public static final String EXTRA_DEVICE_ID =
             "com.nutomic.syncthingandroid.activities.FolderActivity.DEVICE_ID";
 
+
     private static final int DIRECTORY_REQUEST_CODE = 234;
 
     private static final String TAG = "EditFolderFragment";
 
     public static final String KEEP_VERSIONS_DIALOG_TAG = "KeepVersionsDialogFragment";
+    private static final String IS_SHOWING_DELETE_DIALOG =
+            "com.nutomic.syncthingandroid.activities.FolderActivity.DELETE_FOLDER_DIALOG_STATE";
+    private static final String IS_SHOW_DISCARD_DIALOG =
+            "com.nutomic.syncthingandroid.activities.FolderActivity.DISCARD_FOLDER_DIALOG_STATE";
 
     private Folder mFolder;
 
@@ -73,6 +80,11 @@ public class FolderActivity extends SyncthingActivity
 
     private boolean mIsCreateMode;
     private boolean mFolderNeedsToUpdate;
+    private boolean mIsShowingDeleteDialog;
+    private boolean mIsShowingDiscardDialog;
+
+    private Dialog mDeleteDialog;
+    private Dialog mDiscardDialog;
 
     private final KeepVersionsDialogFragment mKeepVersionsDialogFragment = new KeepVersionsDialogFragment();
 
@@ -158,15 +170,27 @@ public class FolderActivity extends SyncthingActivity
         if (mIsCreateMode) {
             if (savedInstanceState != null) {
                 mFolder = new Gson().fromJson(savedInstanceState.getString("folder"), Folder.class);
+                mIsShowingDiscardDialog = savedInstanceState.getBoolean(IS_SHOW_DISCARD_DIALOG);
+                if (mIsShowingDiscardDialog){
+                    showDiscardDialog();
+                }
             }
             if (mFolder == null) {
                 initFolder();
             }
+
             // Open keyboard on label view in edit mode.
             mLabelView.requestFocus();
         }
         else {
             prepareEditMode();
+        }
+
+        if (savedInstanceState != null){
+            mIsShowingDeleteDialog = savedInstanceState.getBoolean(IS_SHOWING_DELETE_DIALOG);
+            if (mIsShowingDeleteDialog){
+                showDeleteDialog();
+            }
         }
     }
 
@@ -192,14 +216,29 @@ public class FolderActivity extends SyncthingActivity
         }
     }
 
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        Log.d("save", mIsShowingDeleteDialog+"");
+        outState.putBoolean(IS_SHOWING_DELETE_DIALOG, mIsShowingDeleteDialog);
+        if (mDeleteDialog != null) {
+            mDeleteDialog.cancel();
+        }
+
+        if (mIsCreateMode){
+            outState.putBoolean(IS_SHOW_DISCARD_DIALOG, mIsShowingDiscardDialog);
+            if(mDiscardDialog != null){
+                mDiscardDialog.cancel();
+            }
+        }
+    }
+
+
     /**
      * Save current settings in case we are in create mode and they aren't yet stored in the config.
      */
-    @Override
-    public void onSaveInstanceState(Bundle outState) {
-        super.onSaveInstanceState(outState);
-        outState.putString("folder", new Gson().toJson(mFolder));
-    }
+
+
 
     @Override
     public void onServiceConnected() {
@@ -309,14 +348,7 @@ public class FolderActivity extends SyncthingActivity
                 finish();
                 return true;
             case R.id.remove:
-                new AlertDialog.Builder(this)
-                        .setMessage(R.string.remove_folder_confirm)
-                        .setPositiveButton(android.R.string.yes, (dialogInterface, i) -> {
-                            getApi().removeFolder(mFolder.id);
-                            finish();
-                        })
-                        .setNegativeButton(android.R.string.no, null)
-                        .show();
+                showDeleteDialog();
                 return true;
             case android.R.id.home:
                 onBackPressed();
@@ -324,6 +356,25 @@ public class FolderActivity extends SyncthingActivity
             default:
                 return super.onOptionsItemSelected(item);
         }
+    }
+
+    private void showDeleteDialog(){
+        mIsShowingDeleteDialog = true;
+        mDeleteDialog = createDeleteDialog();
+        mDeleteDialog.show();
+    }
+
+    private Dialog createDeleteDialog(){
+        return new AlertDialog.Builder(this)
+                .setMessage(R.string.remove_folder_confirm)
+                .setPositiveButton(android.R.string.yes, (dialogInterface, i) -> {
+                    getApi().removeFolder(mFolder.id);
+                    finish();
+                })
+                .setNegativeButton(android.R.string.no, (dialog, which) -> mIsShowingDeleteDialog = false)
+                .setOnCancelListener(dialog -> mIsShowingDeleteDialog = false)
+                .create();
+
     }
 
     @Override
@@ -389,14 +440,25 @@ public class FolderActivity extends SyncthingActivity
     @Override
     public void onBackPressed() {
         if (mIsCreateMode) {
-            new AlertDialog.Builder(this)
-                    .setMessage(R.string.dialog_discard_changes)
-                    .setPositiveButton(android.R.string.ok, (dialog, which) -> finish())
-                    .setNegativeButton(android.R.string.cancel, null)
-                    .show();
+            showDiscardDialog();
         }
         else {
             super.onBackPressed();
         }
+    }
+
+    private void showDiscardDialog(){
+        mDiscardDialog = createDiscardDialog();
+        mDiscardDialog.show();
+        mIsShowingDiscardDialog = true;
+    }
+
+    private Dialog createDiscardDialog() {
+        return new AlertDialog.Builder(this)
+                .setMessage(R.string.dialog_discard_changes)
+                .setPositiveButton(android.R.string.ok, (dialog, which) -> finish())
+                .setNegativeButton(android.R.string.cancel, (dialog, which) -> {mIsShowingDiscardDialog = false;})
+                .setOnCancelListener((dialog -> {mIsShowingDiscardDialog = false;}))
+                .create();
     }
 }

--- a/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
+++ b/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
@@ -64,10 +64,8 @@ public class FolderActivity extends SyncthingActivity
     private static final String TAG = "EditFolderFragment";
 
     public static final String KEEP_VERSIONS_DIALOG_TAG = "KeepVersionsDialogFragment";
-    private static final String IS_SHOWING_DELETE_DIALOG =
-            "com.nutomic.syncthingandroid.activities.FolderActivity.DELETE_FOLDER_DIALOG_STATE";
-    private static final String IS_SHOW_DISCARD_DIALOG =
-            "com.nutomic.syncthingandroid.activities.FolderActivity.DISCARD_FOLDER_DIALOG_STATE";
+    private static final String IS_SHOWING_DELETE_DIALOG = "DELETE_FOLDER_DIALOG_STATE";
+    private static final String IS_SHOW_DISCARD_DIALOG = "DISCARD_FOLDER_DIALOG_STATE";
 
     private Folder mFolder;
 
@@ -80,8 +78,6 @@ public class FolderActivity extends SyncthingActivity
 
     private boolean mIsCreateMode;
     private boolean mFolderNeedsToUpdate;
-    private boolean mIsShowingDeleteDialog;
-    private boolean mIsShowingDiscardDialog;
 
     private Dialog mDeleteDialog;
     private Dialog mDiscardDialog;
@@ -170,15 +166,13 @@ public class FolderActivity extends SyncthingActivity
         if (mIsCreateMode) {
             if (savedInstanceState != null) {
                 mFolder = new Gson().fromJson(savedInstanceState.getString("folder"), Folder.class);
-                mIsShowingDiscardDialog = savedInstanceState.getBoolean(IS_SHOW_DISCARD_DIALOG);
-                if (mIsShowingDiscardDialog){
+                if (savedInstanceState.getBoolean(IS_SHOW_DISCARD_DIALOG)){
                     showDiscardDialog();
                 }
             }
             if (mFolder == null) {
                 initFolder();
             }
-
             // Open keyboard on label view in edit mode.
             mLabelView.requestFocus();
         }
@@ -187,8 +181,7 @@ public class FolderActivity extends SyncthingActivity
         }
 
         if (savedInstanceState != null){
-            mIsShowingDeleteDialog = savedInstanceState.getBoolean(IS_SHOWING_DELETE_DIALOG);
-            if (mIsShowingDeleteDialog){
+            if (savedInstanceState.getBoolean(IS_SHOWING_DELETE_DIALOG)){
                 showDeleteDialog();
             }
         }
@@ -219,27 +212,22 @@ public class FolderActivity extends SyncthingActivity
     @Override
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
-        Log.d("save", mIsShowingDeleteDialog+"");
-        outState.putBoolean(IS_SHOWING_DELETE_DIALOG, mIsShowingDeleteDialog);
+        outState.putBoolean(IS_SHOWING_DELETE_DIALOG, mDeleteDialog != null && mDeleteDialog.isShowing());
         if (mDeleteDialog != null) {
             mDeleteDialog.cancel();
         }
 
         if (mIsCreateMode){
-            outState.putBoolean(IS_SHOW_DISCARD_DIALOG, mIsShowingDiscardDialog);
+            outState.putBoolean(IS_SHOW_DISCARD_DIALOG, mDiscardDialog != null && mDiscardDialog.isShowing());
             if(mDiscardDialog != null){
                 mDiscardDialog.cancel();
             }
         }
     }
 
-
     /**
      * Save current settings in case we are in create mode and they aren't yet stored in the config.
      */
-
-
-
     @Override
     public void onServiceConnected() {
         getService().registerOnApiChangeListener(this);
@@ -359,7 +347,6 @@ public class FolderActivity extends SyncthingActivity
     }
 
     private void showDeleteDialog(){
-        mIsShowingDeleteDialog = true;
         mDeleteDialog = createDeleteDialog();
         mDeleteDialog.show();
     }
@@ -371,10 +358,8 @@ public class FolderActivity extends SyncthingActivity
                     getApi().removeFolder(mFolder.id);
                     finish();
                 })
-                .setNegativeButton(android.R.string.no, (dialog, which) -> mIsShowingDeleteDialog = false)
-                .setOnCancelListener(dialog -> mIsShowingDeleteDialog = false)
+                .setNegativeButton(android.R.string.no, null)
                 .create();
-
     }
 
     @Override
@@ -450,15 +435,13 @@ public class FolderActivity extends SyncthingActivity
     private void showDiscardDialog(){
         mDiscardDialog = createDiscardDialog();
         mDiscardDialog.show();
-        mIsShowingDiscardDialog = true;
     }
 
     private Dialog createDiscardDialog() {
         return new AlertDialog.Builder(this)
                 .setMessage(R.string.dialog_discard_changes)
                 .setPositiveButton(android.R.string.ok, (dialog, which) -> finish())
-                .setNegativeButton(android.R.string.cancel, (dialog, which) -> {mIsShowingDiscardDialog = false;})
-                .setOnCancelListener((dialog -> {mIsShowingDiscardDialog = false;}))
+                .setNegativeButton(android.R.string.cancel, null)
                 .create();
     }
 }

--- a/src/main/java/com/nutomic/syncthingandroid/activities/MainActivity.java
+++ b/src/main/java/com/nutomic/syncthingandroid/activities/MainActivity.java
@@ -59,10 +59,8 @@ public class MainActivity extends SyncthingActivity
         implements SyncthingService.OnApiChangeListener {
 
     private static final String TAG = "MainActivity";
-    private static final String IS_SHOWING_RESTART_DIALOG =
-            "com.nutomic.syncthingandroid.activities.MainActivity.RESTART_DIALOG_STATE";
-    private static final String BATTERY_DIALOG_DISMISSED =
-            "com.nutomic.syncthingandroid.activities.MainActivity.BATTERY_DIALOG_STATE";
+    private static final String IS_SHOWING_RESTART_DIALOG = "RESTART_DIALOG_STATE";
+    private static final String BATTERY_DIALOG_DISMISSED = "BATTERY_DIALOG_STATE";
 
     /**
      * Time after first start when usage reporting dialog should be shown.
@@ -73,12 +71,9 @@ public class MainActivity extends SyncthingActivity
 
     private AlertDialog mDisabledDialog;
     private AlertDialog mBatteryOptimizationsDialog;
-
     private Dialog mRestartDialog;
 
-    private boolean mIsShowingRestartDialog;
     private boolean mBatteryOptimizationDialogDismissed;
-
 
     private ViewPager mViewPager;
 
@@ -225,9 +220,7 @@ public class MainActivity extends SyncthingActivity
             mDrawerFragment = (DrawerFragment) fm.getFragment(
                     savedInstanceState, DrawerFragment.class.getName());
             mViewPager.setCurrentItem(savedInstanceState.getInt("currentTab"));
-
-            mIsShowingRestartDialog = savedInstanceState.getBoolean(IS_SHOWING_RESTART_DIALOG);
-            if (mIsShowingRestartDialog){
+            if (savedInstanceState.getBoolean(IS_SHOWING_RESTART_DIALOG)){
                 showRestartDialog();
             }
             mBatteryOptimizationDialogDismissed = savedInstanceState.getBoolean(BATTERY_DIALOG_DISMISSED);
@@ -281,13 +274,11 @@ public class MainActivity extends SyncthingActivity
             fm.putFragment(outState, DeviceListFragment.class.getName(), mDeviceListFragment);
             fm.putFragment(outState, DrawerFragment.class.getName(), mDrawerFragment);
             outState.putInt("currentTab", mViewPager.getCurrentItem());
-            outState.putBoolean(BATTERY_DIALOG_DISMISSED, mBatteryOptimizationDialogDismissed);
-
-            outState.putBoolean(IS_SHOWING_RESTART_DIALOG, mIsShowingRestartDialog);
+            outState.putBoolean(BATTERY_DIALOG_DISMISSED, mBatteryOptimizationsDialog == null || !mBatteryOptimizationsDialog.isShowing());
+            outState.putBoolean(IS_SHOWING_RESTART_DIALOG, mRestartDialog != null && mRestartDialog.isShowing());
             if (mRestartDialog != null){
                 mRestartDialog.cancel();
             }
-
         }
     }
 
@@ -330,7 +321,6 @@ public class MainActivity extends SyncthingActivity
     public void showRestartDialog(){
         mRestartDialog = createRestartDialog();
         mRestartDialog.show();
-        mIsShowingRestartDialog = true;
     }
 
     private Dialog createRestartDialog(){
@@ -338,8 +328,7 @@ public class MainActivity extends SyncthingActivity
                 .setMessage(R.string.dialog_confirm_restart)
                 .setPositiveButton(android.R.string.yes, (dialogInterface, i1) -> this.startService(new Intent(this, SyncthingService.class)
                         .setAction(SyncthingService.ACTION_RESTART)))
-                .setNegativeButton(android.R.string.no, (dialog, which) -> {mIsShowingRestartDialog = false; })
-                .setOnCancelListener(dialog -> {mIsShowingRestartDialog = false; })
+                .setNegativeButton(android.R.string.no, null)
                 .create();
     }
 

--- a/src/main/java/com/nutomic/syncthingandroid/fragments/DrawerFragment.java
+++ b/src/main/java/com/nutomic/syncthingandroid/fragments/DrawerFragment.java
@@ -41,10 +41,7 @@ public class DrawerFragment extends Fragment implements View.OnClickListener {
     private TextView mUpload;
     private TextView mAnnounceServer;
     private TextView mVersion;
-
     private TextView mExitButton;
-
-
 
     private Timer mTimer;
 
@@ -225,6 +222,4 @@ public class DrawerFragment extends Fragment implements View.OnClickListener {
                 break;
         }
     }
-
-
 }

--- a/src/main/java/com/nutomic/syncthingandroid/fragments/DrawerFragment.java
+++ b/src/main/java/com/nutomic/syncthingandroid/fragments/DrawerFragment.java
@@ -1,6 +1,7 @@
 package com.nutomic.syncthingandroid.fragments;
 
 import android.app.AlertDialog;
+import android.app.Dialog;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
@@ -42,6 +43,8 @@ public class DrawerFragment extends Fragment implements View.OnClickListener {
     private TextView mVersion;
 
     private TextView mExitButton;
+
+
 
     private Timer mTimer;
 
@@ -212,13 +215,8 @@ public class DrawerFragment extends Fragment implements View.OnClickListener {
                 mActivity.closeDrawer();
                 break;
             case R.id.drawerActionRestart:
+                mActivity.showRestartDialog();
                 mActivity.closeDrawer();
-                new AlertDialog.Builder(getContext())
-                        .setMessage(R.string.dialog_confirm_restart)
-                        .setPositiveButton(android.R.string.yes, (dialogInterface, i1) -> getContext().startService(new Intent(getContext(), SyncthingService.class)
-                                .setAction(SyncthingService.ACTION_RESTART)))
-                        .setNegativeButton(android.R.string.no, null)
-                        .show();
                 break;
             case R.id.drawerActionExit:
                 mActivity.stopService(new Intent(mActivity, SyncthingService.class));
@@ -227,4 +225,6 @@ public class DrawerFragment extends Fragment implements View.OnClickListener {
                 break;
         }
     }
+
+
 }

--- a/src/main/java/com/nutomic/syncthingandroid/fragments/dialog/KeepVersionsDialogFragment.java
+++ b/src/main/java/com/nutomic/syncthingandroid/fragments/dialog/KeepVersionsDialogFragment.java
@@ -6,6 +6,7 @@ import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v7.app.AlertDialog;
+import android.util.Log;
 import android.widget.FrameLayout.LayoutParams;
 import android.widget.NumberPicker;
 
@@ -15,6 +16,8 @@ import static android.view.Gravity.CENTER;
 import static android.view.ViewGroup.LayoutParams.WRAP_CONTENT;
 
 public class KeepVersionsDialogFragment extends DialogFragment {
+
+    private static String KEEP_VERSION_VALUE = "com.nutomic.syncthingandroid.fragments.dialog.KeepVersionsDialogFragment.KEEP_VERSION_KEY";
 
     private OnValueChangeListener mOnValueChangeListener;
 
@@ -38,6 +41,10 @@ public class KeepVersionsDialogFragment extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
+        if (savedInstanceState != null) {
+            setValue(savedInstanceState.getInt(KEEP_VERSION_VALUE));
+        }
+
         mNumberPickerView = createNumberPicker();
         return new AlertDialog.Builder(getActivity())
                 .setTitle(R.string.keep_versions)
@@ -46,6 +53,14 @@ public class KeepVersionsDialogFragment extends DialogFragment {
                 .setNegativeButton(android.R.string.cancel, null)
                 .create();
     }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putInt(KEEP_VERSION_VALUE, getValue());
+    }
+
+
 
     public void setOnValueChangeListener(OnValueChangeListener onValueChangeListener) {
         mOnValueChangeListener = onValueChangeListener;
@@ -57,6 +72,15 @@ public class KeepVersionsDialogFragment extends DialogFragment {
         if (mNumberPickerView != null) {
             mNumberPickerView.setValue(value);
         }
+        Log.d("folder", "setValue: "+value);
+    }
+
+    private int getValue(){
+        int value = 0;
+        if (mNumberPickerView != null){
+            value = mNumberPickerView.getValue();
+        }
+        return value;
     }
 
     private NumberPicker createNumberPicker() {
@@ -66,6 +90,7 @@ public class KeepVersionsDialogFragment extends DialogFragment {
         picker.setMaxValue(5);
         picker.setValue(mValue);
         picker.setWrapSelectorWheel(false);
+        Log.d("folder fragment", "create number picker "+mValue);
         return picker;
     }
 

--- a/src/main/java/com/nutomic/syncthingandroid/fragments/dialog/KeepVersionsDialogFragment.java
+++ b/src/main/java/com/nutomic/syncthingandroid/fragments/dialog/KeepVersionsDialogFragment.java
@@ -17,7 +17,7 @@ import static android.view.ViewGroup.LayoutParams.WRAP_CONTENT;
 
 public class KeepVersionsDialogFragment extends DialogFragment {
 
-    private static String KEEP_VERSION_VALUE = "com.nutomic.syncthingandroid.fragments.dialog.KeepVersionsDialogFragment.KEEP_VERSION_KEY";
+    private static String KEEP_VERSION_VALUE = "KEEP_VERSION_KEY";
 
     private OnValueChangeListener mOnValueChangeListener;
 
@@ -57,10 +57,8 @@ public class KeepVersionsDialogFragment extends DialogFragment {
     @Override
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
-        outState.putInt(KEEP_VERSION_VALUE, getValue());
+        outState.putInt(KEEP_VERSION_VALUE, mNumberPickerView.getValue());
     }
-
-
 
     public void setOnValueChangeListener(OnValueChangeListener onValueChangeListener) {
         mOnValueChangeListener = onValueChangeListener;
@@ -72,15 +70,6 @@ public class KeepVersionsDialogFragment extends DialogFragment {
         if (mNumberPickerView != null) {
             mNumberPickerView.setValue(value);
         }
-        Log.d("folder", "setValue: "+value);
-    }
-
-    private int getValue(){
-        int value = 0;
-        if (mNumberPickerView != null){
-            value = mNumberPickerView.getValue();
-        }
-        return value;
     }
 
     private NumberPicker createNumberPicker() {
@@ -90,7 +79,6 @@ public class KeepVersionsDialogFragment extends DialogFragment {
         picker.setMaxValue(5);
         picker.setValue(mValue);
         picker.setWrapSelectorWheel(false);
-        Log.d("folder fragment", "create number picker "+mValue);
         return picker;
     }
 


### PR DESCRIPTION
 - Used onSaveIntance() to save dialog state while the activity is being recreated.