### PR TITLE
fixed typo with send/recv rate limit

### DIFF
--- a/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -233,7 +233,7 @@ public class SettingsActivity extends SyncthingActivity {
                     mOptions.listenAddresses = Iterables.toArray(splitter.split((String) o), String.class);
                     break;
                 case "maxRecvKbps":           mOptions.maxRecvKbps = Integer.parseInt((String) o); break;
-                case "maxSendKbps":           mOptions.maxRecvKbps = Integer.parseInt((String) o); break;
+                case "maxSendKbps":           mOptions.maxSendKbps = Integer.parseInt((String) o); break;
                 case "natEnabled":            mOptions.natEnabled = (boolean) o;                   break;
                 case "localAnnounceEnabled":  mOptions.localAnnounceEnabled = (boolean) o;         break;
                 case "globalAnnounceEnabled": mOptions.globalAnnounceEnabled = (boolean) o;        break;


### PR DESCRIPTION
To fix issue #911 

Given how simple the change is, we can be pretty confident that the patch works, by inspection.
However I haven't actually compiled and run this to check that it works. 

I'm quite new to Android, and I couldn't get the current master branch to work on my phone. It did compile, but I got an error message at runtime about not being able to create a config file. I gave up trying to physically run this version on my phone, but I'm pretty confident.