### PR TITLE
Use API key as password for web GUI (fixes #868)

### DIFF
--- a/src/main/java/com/nutomic/syncthingandroid/activities/WebGuiActivity.java
+++ b/src/main/java/com/nutomic/syncthingandroid/activities/WebGuiActivity.java
@@ -87,9 +87,7 @@ public class WebGuiActivity extends SyncthingActivity
         }
 
         public void onReceivedHttpAuthRequest(WebView view, HttpAuthHandler handler, String host, String realm) {
-            String password = PreferenceManager.getDefaultSharedPreferences(WebGuiActivity.this)
-                    .getString("web_gui_password", "");
-            handler.proceed(mConfig.getUserName(), password);
+            handler.proceed(mConfig.getUserName(), mConfig.getApiKey());
         }
 
         @Override

--- a/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
+++ b/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
@@ -217,12 +217,9 @@ public class ConfigXml {
      * The password in the config is hashed, so we can't use it directly.
      */
     private void generateLoginInfo() {
-        String user = Build.MODEL.replaceAll("[^a-zA-Z0-9 ]", "");
-        Log.i(TAG, "Generated GUI username and password (username is " + user + ")");
-
         Node userNode = mConfig.createElement("user");
         getGuiElement().appendChild(userNode);
-        userNode.setTextContent(user);
+        userNode.setTextContent("syncthing");
 
         Node passwordNode = mConfig.createElement("password");
         getGuiElement().appendChild(passwordNode);

--- a/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
+++ b/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
@@ -211,19 +211,12 @@ public class ConfigXml {
     }
 
     /**
-     * Generates username and config, stores them in config and preferences.
+     * Generates username and password, stores them in config.
      *
-     * We have to store the plaintext password in preferences, because we need it in
-     * WebGuiActivity. The password in the config is hashed, so we can't use it directly.
+     * The API key is used as the password, because we need it in WebGuiActivity.
+     * The password in the config is hashed, so we can't use it directly.
      */
     private void generateLoginInfo() {
-        char[] chars =
-                "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz".toCharArray();
-        StringBuilder password = new StringBuilder();
-        SecureRandom random = new SecureRandom();
-        for (int i = 0; i < 20; i++)
-            password.append(chars[random.nextInt(chars.length)]);
-
         String user = Build.MODEL.replaceAll("[^a-zA-Z0-9 ]", "");
         Log.i(TAG, "Generated GUI username and password (username is " + user + ")");
 
@@ -233,11 +226,8 @@ public class ConfigXml {
 
         Node passwordNode = mConfig.createElement("password");
         getGuiElement().appendChild(passwordNode);
-        String hashed = BCrypt.hashpw(password.toString(), BCrypt.gensalt());
+        String hashed = BCrypt.hashpw(getApiKey(), BCrypt.gensalt());
         passwordNode.setTextContent(hashed);
-        PreferenceManager.getDefaultSharedPreferences(mContext).edit()
-                .putString("web_gui_password", password.toString())
-                .apply();
     }
 
     /**


### PR DESCRIPTION
A random password can't be retrieved after export and import of settings.