### PR TITLE
Remove custom user and password (fixes #868)

### DIFF
--- a/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -65,8 +65,6 @@ public class SettingsActivity extends SyncthingActivity {
         private CheckBoxPreference mRelaysEnabled;
         private EditTextPreference mGlobalAnnounceServers;
         private EditTextPreference mAddress;
-        private EditTextPreference mUser;
-        private EditTextPreference mPassword;
         private CheckBoxPreference mUrAccepted;
 
         private CheckBoxPreference mUseRoot;
@@ -115,8 +113,6 @@ public class SettingsActivity extends SyncthingActivity {
             mRelaysEnabled          = (CheckBoxPreference) findPreference("relaysEnabled");
             mGlobalAnnounceServers  = (EditTextPreference) findPreference("globalAnnounceServers");
             mAddress                = (EditTextPreference) findPreference("address");
-            mUser                   = (EditTextPreference) findPreference("user");
-            mPassword               = (EditTextPreference) findPreference("password");
             mUrAccepted             = (CheckBoxPreference) findPreference("urAccepted");
 
             Preference exportConfig = findPreference("export_config");
@@ -200,8 +196,6 @@ public class SettingsActivity extends SyncthingActivity {
             mRelaysEnabled.setChecked(mOptions.relaysEnabled);
             mGlobalAnnounceServers.setText(joiner.join(mOptions.globalAnnounceServers));
             mAddress.setText(mGui.address);
-            mUser.setText(mGui.user);
-            mPassword.setText(mGui.password);
             mUrAccepted.setChecked(mOptions.getUsageReportValue() == Options.USAGE_REPORTING_ACCEPTED);
         }
 
@@ -242,8 +236,6 @@ public class SettingsActivity extends SyncthingActivity {
                     mOptions.globalAnnounceServers = Iterables.toArray(splitter.split((String) o), String.class);
                     break;
                 case "address":               mGui.address = (String) o;  break;
-                case "user":                  mGui.user = (String) o;     break;
-                case "password":              mGui.password = (String) o; break;
                 case "urAccepted":
                     mOptions.urAccepted = ((boolean) o)
                             ? Options.USAGE_REPORTING_ACCEPTED

--- a/src/main/java/com/nutomic/syncthingandroid/activities/WebGuiActivity.java
+++ b/src/main/java/com/nutomic/syncthingandroid/activities/WebGuiActivity.java
@@ -87,9 +87,7 @@ public class WebGuiActivity extends SyncthingActivity
         }
 
         public void onReceivedHttpAuthRequest(WebView view, HttpAuthHandler handler, String host, String realm) {
-            String password = PreferenceManager.getDefaultSharedPreferences(WebGuiActivity.this)
-                    .getString("web_gui_password", "");
-            handler.proceed(mConfig.getUserName(), password);
+            handler.proceed(mConfig.getUserName(), mConfig.getApiKey());
         }
 
         @Override

--- a/src/main/res/xml/app_settings.xml
+++ b/src/main/res/xml/app_settings.xml
@@ -113,17 +113,6 @@
             android:persistent="false"
             android:inputType="textNoSuggestions" />
 
-        <EditTextPreference
-            android:key="user"
-            android:title="@string/gui_user"
-            android:inputType="textCapWords"
-            android:persistent="false" />
-
-        <EditTextPreference
-            android:key="password"
-            android:title="@string/gui_password"
-            android:inputType="textVisiblePassword" />
-
         <CheckBoxPreference
             android:key="urAccepted"
             android:title="@string/usage_reporting"


### PR DESCRIPTION
This removes the ability to set a custom user and password.
The user is always set to "syncthing" and the password to the API key.
This ensure that the web GUI works and makes sure that the web GUI is protected.

This is an alternative approach to #920.