### PR TITLE
Show error when folder is out of sync

### DIFF
--- a/src/main/java/com/nutomic/syncthingandroid/model/Model.java
+++ b/src/main/java/com/nutomic/syncthingandroid/model/Model.java
@@ -12,6 +12,8 @@ public class Model {
     public long needBytes;
     public long needFiles;
     public long needDeletes;
+    public long needDirectories;
+    public long needSymlinks;
     public String state;
     public String invalid;
 }

--- a/src/main/java/com/nutomic/syncthingandroid/views/FoldersAdapter.java
+++ b/src/main/java/com/nutomic/syncthingandroid/views/FoldersAdapter.java
@@ -66,7 +66,12 @@ public class FoldersAdapter extends ArrayAdapter<Folder> {
             int percentage = (model.localBytes != 0)
                     ? Math.round(100 * model.inSyncBytes / model.localBytes)
                     : 100;
-            binding.state.setText(getLocalizedState(getContext(), model.state, percentage));
+            long neededItems = model.needFiles + model.needDirectories + model.needSymlinks + model.needDeletes;
+            if (model.state.equals("idle") && neededItems > 0) {
+                binding.state.setText(getContext().getString(R.string.status_outofsync));
+            } else {
+                binding.state.setText(getLocalizedState(getContext(), model.state, percentage));
+            }
             binding.items.setVisibility(VISIBLE);
             binding.items.setText(getContext()
                     .getString(R.string.files, model.inSyncFiles, model.localFiles));

--- a/src/main/java/com/nutomic/syncthingandroid/views/FoldersAdapter.java
+++ b/src/main/java/com/nutomic/syncthingandroid/views/FoldersAdapter.java
@@ -50,7 +50,6 @@ public class FoldersAdapter extends ArrayAdapter<Folder> {
         Folder folder = getItem(position);
         Model model = mModels.get(folder.id);
         binding.label.setText(TextUtils.isEmpty(folder.label) ? folder.id : folder.label);
-        binding.state.setTextColor(ContextCompat.getColor(getContext(), R.color.text_green));
         binding.directory.setText(folder.path);
         binding.openFolder.setOnClickListener(v -> {
             Intent intent = new Intent(Intent.ACTION_VIEW);
@@ -69,8 +68,21 @@ public class FoldersAdapter extends ArrayAdapter<Folder> {
             long neededItems = model.needFiles + model.needDirectories + model.needSymlinks + model.needDeletes;
             if (model.state.equals("idle") && neededItems > 0) {
                 binding.state.setText(getContext().getString(R.string.status_outofsync));
+                binding.state.setTextColor(ContextCompat.getColor(getContext(), R.color.text_red));
             } else {
                 binding.state.setText(getLocalizedState(getContext(), model.state, percentage));
+                switch(model.state) {
+                    case "idle":
+                        binding.state.setTextColor(ContextCompat.getColor(getContext(), R.color.text_green));
+                        break;
+                    case "scanning":
+                    case "cleaning":
+                    case "syncing":
+                        binding.state.setTextColor(ContextCompat.getColor(getContext(), R.color.text_blue));
+                        break;
+                    default:
+                        binding.state.setTextColor(ContextCompat.getColor(getContext(), R.color.text_red));
+                }
             }
             binding.items.setVisibility(VISIBLE);
             binding.items.setText(getContext()

--- a/src/main/res/values-bg/strings.xml
+++ b/src/main/res/values-bg/strings.xml
@@ -304,6 +304,7 @@
   <string name="state_syncing">Синхронизиране (%1$d%%)</string>
   <string name="state_error">Грешка</string>
   <string name="state_unknown">Неясно</string>
+  <string name="status_outofsync">Несинхронизирано</string>
   <!--Format string for folder size, eg "500 MiB / 1 GiB"-->
   <string name="folder_size_format">%1$s / %2$s</string>
 </resources>

--- a/src/main/res/values-cs/strings.xml
+++ b/src/main/res/values-cs/strings.xml
@@ -314,6 +314,7 @@ Všechny zaznamenané chyby prosím hlašte přes Github.</string>
   <string name="state_syncing">Synchronizuje se (%1$d%%)</string>
   <string name="state_error">Chyba</string>
   <string name="state_unknown">Neznámý</string>
+  <string name="status_outofsync">Nesesynchronizováno</string>
   <!--Format string for folder size, eg "500 MiB / 1 GiB"-->
   <string name="folder_size_format">%1$s / %2$s</string>
   <string name="appconfig_receiver_background_enabled">Syncthing nelze zastavit když je povolený běh na pozadí.</string>

--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -308,6 +308,7 @@ Bitte melden Sie auftretende Probleme via Github.</string>
   <string name="state_syncing">Synchronisiere (%1$d%%)</string>
   <string name="state_error">Fehler</string>
   <string name="state_unknown">Unbekannt</string>
+  <string name="status_outofsync">Nicht synchronisiert</string>
   <!--Format string for folder size, eg "500 MiB / 1 GiB"-->
   <string name="folder_size_format">%1$s / %2$s</string>
   <string name="appconfig_receiver_background_enabled">Syncthing zu stoppen wird nicht unterstützt solange das Ausführen im Hintergrund aktiviert ist.</string>

--- a/src/main/res/values-el/strings.xml
+++ b/src/main/res/values-el/strings.xml
@@ -319,6 +319,7 @@
   <string name="state_syncing">Συγχρονισμός (%1$d%%)</string>
   <string name="state_error">Σφάλμα</string>
   <string name="state_unknown">Άγνωστο</string>
+  <string name="status_outofsync">Μη συγχρονισμένα</string>
   <!--Format string for folder size, eg "500 MiB / 1 GiB"-->
   <string name="folder_size_format">%1$s / %2$s</string>
   <string name="appconfig_receiver_background_enabled">Ο τερματισμός του Syncthing δεν υποστηρίζεται όταν έχει ενεργοποιηθεί η εκτέλεση στο παρασκήνιο.</string>

--- a/src/main/res/values-es-rMX/strings.xml
+++ b/src/main/res/values-es-rMX/strings.xml
@@ -283,6 +283,7 @@
   <string name="state_syncing">Sincronizando (%1$d%%)</string>
   <string name="state_error">Error</string>
   <string name="state_unknown">Desconocido</string>
+  <string name="status_outofsync">No sincronizado</string>
   <!--Format string for folder size, eg "500 MiB / 1 GiB"-->
   <string name="folder_size_format">%1$s / %2$s</string>
 </resources>

--- a/src/main/res/values-es/strings.xml
+++ b/src/main/res/values-es/strings.xml
@@ -310,6 +310,7 @@
   <string name="state_syncing">Sincronizando (%1$d%%)</string>
   <string name="state_error">Error</string>
   <string name="state_unknown">Desconocido</string>
+  <string name="status_outofsync">No sincronizado</string>
   <!--Format string for folder size, eg "500 MiB / 1 GiB"-->
   <string name="folder_size_format">%1$s / %2$s</string>
   <string name="appconfig_receiver_background_enabled">No está soportado detener Syncthing mientras está activada la ejecución en segundo plano.</string>

--- a/src/main/res/values-fi/strings.xml
+++ b/src/main/res/values-fi/strings.xml
@@ -305,6 +305,7 @@ Ilmoitathan ystävällisesti kaikista havaitsemistasi ongelmista Githubin kautta
   <string name="state_syncing">Synkronoidaan (%1$d%%)</string>
   <string name="state_error">Virhe</string>
   <string name="state_unknown">Tuntematon</string>
+  <string name="status_outofsync">Ei ajan tasalla</string>
   <!--Format string for folder size, eg "500 MiB / 1 GiB"-->
   <string name="folder_size_format">%1$s / %2$s</string>
   <string name="appconfig_receiver_background_enabled">Syncthingin pysäyttäminen ei ole käytettävissä kun käynti taustalla on valittuna.</string>

--- a/src/main/res/values-fr/strings.xml
+++ b/src/main/res/values-fr/strings.xml
@@ -319,6 +319,7 @@ S\'il vous plaît, soumettez les problèmes que vous rencontrez via Github.</str
   <string name="state_syncing">Synchronisation (%1$d%%)</string>
   <string name="state_error">Erreur</string>
   <string name="state_unknown">Inconnu</string>
+  <string name="status_outofsync">Désynchronisé</string>
   <!--Format string for folder size, eg "500 MiB / 1 GiB"-->
   <string name="folder_size_format">%1$s / %2$s</string>
   <string name="appconfig_receiver_background_enabled">L\'arrêt de Syncthing n\'est pas supporté quand le fonctionnement en tâche de fond est activé.</string>

--- a/src/main/res/values-hu/strings.xml
+++ b/src/main/res/values-hu/strings.xml
@@ -224,5 +224,6 @@
   <string name="state_syncing">Szinkronizálás (%1$d%%)</string>
   <string name="state_error">Hiba</string>
   <string name="state_unknown">Ismeretlen</string>
+  <string name="status_outofsync">Nincs szinkronban</string>
   <!--Format string for folder size, eg "500 MiB / 1 GiB"-->
 </resources>

--- a/src/main/res/values-it/strings.xml
+++ b/src/main/res/values-it/strings.xml
@@ -319,6 +319,7 @@ Si prega di segnalare eventuali problemi che si incontrano via Github.</string>
   <string name="state_syncing">Sincronizzazione (%1$d%%)</string>
   <string name="state_error">Errore</string>
   <string name="state_unknown">Sconosciuto</string>
+  <string name="status_outofsync">Non sincronizzato</string>
   <!--Format string for folder size, eg "500 MiB / 1 GiB"-->
   <string name="folder_size_format">%1$s / %2$s</string>
   <string name="appconfig_receiver_background_enabled">Arrestare Syncthing non è  possibile quando è abilitato il funzionamento in background.</string>

--- a/src/main/res/values-ja/strings.xml
+++ b/src/main/res/values-ja/strings.xml
@@ -337,6 +337,7 @@
   <string name="state_syncing">同期中 (%1$d%%)</string>
   <string name="state_error">エラー</string>
   <string name="state_unknown">不明</string>
+  <string name="status_outofsync">未同期</string>
   <!--Format string for folder size, eg "500 MiB / 1 GiB"-->
   <string name="folder_size_format">%1$s / %2$s</string>
   <string name="appconfig_receiver_background_enabled">バックグラウンドでの実行が有効になっているとき、Syncthing の停止はサポートされていません。</string>

--- a/src/main/res/values-ko/strings.xml
+++ b/src/main/res/values-ko/strings.xml
@@ -337,6 +337,7 @@
   <string name="state_syncing">동기화 중 (%1$d%%)</string>
   <string name="state_error">오류</string>
   <string name="state_unknown">알 수 없음</string>
+  <string name="status_outofsync">동기화 오류</string>
   <!--Format string for folder size, eg "500 MiB / 1 GiB"-->
   <string name="folder_size_format">%1$s / %2$s</string>
   <string name="appconfig_receiver_background_enabled">백그라운드에서 실행이 활성화되어 있을 때는 Syncthing 중단은 지원되지 않습니다.</string>

--- a/src/main/res/values-nb/strings.xml
+++ b/src/main/res/values-nb/strings.xml
@@ -291,6 +291,7 @@
   <string name="state_syncing">Synkroniserer (%1$d%%)</string>
   <string name="state_error">Feil</string>
   <string name="state_unknown">Ukjent</string>
+  <string name="status_outofsync">Ikke synkronisert</string>
   <!--Format string for folder size, eg "500 MiB / 1 GiB"-->
   <string name="folder_size_format">%1$s / %2$s</string>
   <string name="appconfig_receiver_background_enabled">Du kan ikke stoppe Syncthing når «kjør i bakgrunnen» er skrudd på.</string>

--- a/src/main/res/values-nl/strings.xml
+++ b/src/main/res/values-nl/strings.xml
@@ -318,6 +318,7 @@ Als je problemen tegenkomt, meld ze dan via GitHub.</string>
   <string name="state_syncing">Bezig met synchroniseren (%1$d%%)</string>
   <string name="state_error">Fout</string>
   <string name="state_unknown">Onbekend</string>
+  <string name="status_outofsync">Niet gesynchroniseerd</string>
   <!--Format string for folder size, eg "500 MiB / 1 GiB"-->
   <string name="folder_size_format">%1$s / %2$s</string>
   <string name="appconfig_receiver_background_enabled">Syncthing stoppen terwijl uitvoeren in achtergrond is ingeschakeld wordt niet ondersteund.</string>

--- a/src/main/res/values-nn/strings.xml
+++ b/src/main/res/values-nn/strings.xml
@@ -290,6 +290,7 @@
   <string name="state_syncing">Synkroniserer (%1$d%%)</string>
   <string name="state_error">Feil</string>
   <string name="state_unknown">Ukjend</string>
+  <string name="status_outofsync">Ikkje synkronisert</string>
   <!--Format string for folder size, eg "500 MiB / 1 GiB"-->
   <string name="folder_size_format">%1$s / %2$s</string>
   <string name="appconfig_receiver_background_enabled">Du kan ikkje stoppe Syncthing når «køyr i bakgrunnen» er skrudd på.</string>

--- a/src/main/res/values-pl/strings.xml
+++ b/src/main/res/values-pl/strings.xml
@@ -307,6 +307,7 @@ Proszę zgłaszać napotkane błędy programu za pośrednictwem serwisu Github.<
   <string name="state_syncing">Synchronizowanie (%1$d%%)</string>
   <string name="state_error">Błąd</string>
   <string name="state_unknown">Nieznany</string>
+  <string name="status_outofsync">Niezsynchronizowane</string>
   <!--Format string for folder size, eg "500 MiB / 1 GiB"-->
   <string name="folder_size_format">%1$s / %2$s</string>
   <string name="appconfig_receiver_background_enabled">Zatrzymywanie programu nie jest obsługiwane podczas działania w tle.</string>

--- a/src/main/res/values-pt-rBR/strings.xml
+++ b/src/main/res/values-pt-rBR/strings.xml
@@ -319,6 +319,7 @@ Por favor, nos avise sobre quaisquer problemas que você encontrar via Github.</
   <string name="state_syncing">Sincronizando (%1$d%%)</string>
   <string name="state_error">Erro</string>
   <string name="state_unknown">Desconhecido</string>
+  <string name="status_outofsync">Fora de sincronia</string>
   <!--Format string for folder size, eg "500 MiB / 1 GiB"-->
   <string name="folder_size_format">%1$s / %2$s</string>
   <string name="appconfig_receiver_background_enabled">Não é possível parar o Syncthing enquanto ele estiver configurado para rodar em segundo plano.</string>

--- a/src/main/res/values-pt/strings.xml
+++ b/src/main/res/values-pt/strings.xml
@@ -313,6 +313,7 @@ Reporte, através do Github, quaisquer problemas que encontre, por favor.</strin
   <string name="state_syncing">Sincronizando (%1$d%%)</string>
   <string name="state_error">Erro</string>
   <string name="state_unknown">Desconhecido</string>
+  <string name="status_outofsync">Fora de sincronia</string>
   <!--Format string for folder size, eg "500 MiB / 1 GiB"-->
   <string name="folder_size_format">%1$s / %2$s</string>
   <string name="appconfig_receiver_background_enabled">Parar o Syncthing não é suportado quando está activada a opção para correr em segundo plano.</string>

--- a/src/main/res/values-ru/strings.xml
+++ b/src/main/res/values-ru/strings.xml
@@ -319,6 +319,7 @@
   <string name="state_syncing">Синхронизация (%1$d%%)</string>
   <string name="state_error">Ошибка</string>
   <string name="state_unknown">Неизвестно</string>
+  <string name="status_outofsync">Нет синхронизации</string>
   <!--Format string for folder size, eg "500 MiB / 1 GiB"-->
   <string name="folder_size_format">%1$s / %2$s</string>
   <string name="appconfig_receiver_background_enabled">Остановка Syncthing не поддерживается, если включено выполнение в фоновом режиме.</string>

--- a/src/main/res/values-sk/strings.xml
+++ b/src/main/res/values-sk/strings.xml
@@ -268,5 +268,6 @@ Naozaj chcete resetovať databázu s indexom súborov?</string>
   <string name="state_syncing">Synchronizuje sa (%1$d%%)</string>
   <string name="state_error">Chyba</string>
   <string name="state_unknown">Neznámy</string>
+  <string name="status_outofsync">Nesynchronizované</string>
   <!--Format string for folder size, eg "500 MiB / 1 GiB"-->
 </resources>

--- a/src/main/res/values-sv/strings.xml
+++ b/src/main/res/values-sv/strings.xml
@@ -340,6 +340,7 @@ Vänligen rapportera eventuella problem du stöter på via Github.</string>
   <string name="state_syncing">Synkroniserar (%1$d%%)</string>
   <string name="state_error">Fel</string>
   <string name="state_unknown">Okänd</string>
+  <string name="status_outofsync">Osynkroniserad</string>
   <!--Format string for folder size, eg "500 MiB / 1 GiB"-->
   <string name="folder_size_format">%1$s / %2$s</string>
   <string name="appconfig_receiver_background_enabled">Det går inte att stoppa Syncthing när körning i bakgrunden är aktiverad.</string>

--- a/src/main/res/values-tr/strings.xml
+++ b/src/main/res/values-tr/strings.xml
@@ -312,6 +312,7 @@ Eğer herhangi bir sorunla karşılaşırsan Github aracılığıyla bildir.</st
   <string name="state_syncing">Eşzamanlama gerçekleştiriliyor (%1$d%%)</string>
   <string name="state_error">Hata</string>
   <string name="state_unknown">Bilinmiyor</string>
+  <string name="status_outofsync">Eşzamanlama Dışı</string>
   <!--Format string for folder size, eg "500 MiB / 1 GiB"-->
   <string name="folder_size_format">%1$s / %2$s</string>
   <string name="appconfig_receiver_background_enabled">Arka planda çalışma etkinken Syncthing\'i durdurma desteklenmiyor.</string>

--- a/src/main/res/values-vi/strings.xml
+++ b/src/main/res/values-vi/strings.xml
@@ -283,6 +283,7 @@
   <string name="state_syncing">Đang đ.bộ (%1$d%%)</string>
   <string name="state_error">Lỗi</string>
   <string name="state_unknown">Không rõ</string>
+  <string name="status_outofsync">Mất đồng bộ</string>
   <!--Format string for folder size, eg "500 MiB / 1 GiB"-->
   <string name="folder_size_format">%1$s / %2$s</string>
 </resources>

--- a/src/main/res/values-zh-rCN/strings.xml
+++ b/src/main/res/values-zh-rCN/strings.xml
@@ -339,6 +339,7 @@
   <string name="state_syncing">正在同步 (%1$d%%)</string>
   <string name="state_error">错误</string>
   <string name="state_unknown">未知</string>
+  <string name="status_outofsync">未同步</string>
   <!--Format string for folder size, eg "500 MiB / 1 GiB"-->
   <string name="folder_size_format">%1$s / %2$s</string>
   <string name="appconfig_receiver_background_enabled">当启用后台运行时不支持停止 Syncthing。</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -556,6 +556,7 @@ Please report any problems you encounter via Github.</string>
     <string name="state_syncing">Syncing (%1$d%%)</string>
     <string name="state_error">Error</string>
     <string name="state_unknown">Unknown</string>
+    <string name="status_outofsync">Out of Sync</string>
 
     <!-- Format string for folder size, eg "500 MiB / 1 GiB" -->
     <string name="folder_size_format">%1$s / %2$s</string>


### PR DESCRIPTION
If a folder is out of sync the app shows that the folder is idle. Only the web GUI shows the problem.
I copied the translations from Syncthing and also colorized the folder status message.