### PR TITLE
Addressing #899 and #898.

### DIFF
--- a/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
+++ b/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
@@ -141,7 +141,7 @@ public class FolderActivity extends SyncthingActivity
         mEditIgnores = findViewById(R.id.edit_ignores);
 
         mPathView.setOnClickListener(view ->
-                startActivityForResult(FolderPickerActivity.createIntent(this, mFolder.path), FolderPickerActivity.DIRECTORY_REQUEST_CODE));
+                startActivityForResult(FolderPickerActivity.createIntent(this, mFolder.path, null), FolderPickerActivity.DIRECTORY_REQUEST_CODE));
 
         findViewById(R.id.versioningContainer).setOnClickListener(v -> showVersioningDialog());
         mEditIgnores.setOnClickListener(v -> editIgnores());
@@ -383,9 +383,6 @@ public class FolderActivity extends SyncthingActivity
                 .setMessage(R.string.remove_folder_confirm)
                 .setPositiveButton(android.R.string.yes, (dialogInterface, i) -> {
                     getApi().removeFolder(mFolder.id);
-                    //Remove saved data from share activity for this folder.
-                    SharedPreferences prefs = this.getSharedPreferences(ShareActivity.SHARED_PREFS_SAVED_DIRECTORIES, MODE_PRIVATE);
-                    prefs.edit().remove(mFolder.id).apply();
                     finish();
                 })
                 .setNegativeButton(android.R.string.no, null)

--- a/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
+++ b/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
@@ -5,7 +5,7 @@ import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.ActivityNotFoundException;
 import android.content.Intent;
-import android.net.Uri;
+import android.content.SharedPreferences;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.v7.widget.SwitchCompat;
@@ -383,6 +383,9 @@ public class FolderActivity extends SyncthingActivity
                 .setMessage(R.string.remove_folder_confirm)
                 .setPositiveButton(android.R.string.yes, (dialogInterface, i) -> {
                     getApi().removeFolder(mFolder.id);
+                    //Remove saved data from share activity for this folder.
+                    SharedPreferences prefs = this.getSharedPreferences(ShareActivity.SHARED_PREFS_SAVED_DIRECTORIES, MODE_PRIVATE);
+                    prefs.edit().remove(mFolder.id).apply();
                     finish();
                 })
                 .setNegativeButton(android.R.string.no, null)

--- a/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
+++ b/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
@@ -5,7 +5,7 @@ import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.ActivityNotFoundException;
 import android.content.Intent;
-import android.content.SharedPreferences;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.v7.widget.SwitchCompat;

--- a/src/main/java/com/nutomic/syncthingandroid/activities/FolderPickerActivity.java
+++ b/src/main/java/com/nutomic/syncthingandroid/activities/FolderPickerActivity.java
@@ -33,6 +33,7 @@ import com.google.common.collect.Sets;
 import com.nutomic.syncthingandroid.R;
 import com.nutomic.syncthingandroid.SyncthingApp;
 import com.nutomic.syncthingandroid.service.SyncthingService;
+import com.nutomic.syncthingandroid.util.Util;
 
 import org.w3c.dom.Text;
 
@@ -198,7 +199,7 @@ public class FolderPickerActivity extends SyncthingActivity
                 return true;
             case R.id.select:
                 Intent intent = new Intent()
-                        .putExtra(EXTRA_RESULT_DIRECTORY, mLocation.getAbsolutePath());
+                        .putExtra(EXTRA_RESULT_DIRECTORY, Util.formatPath(mLocation.getAbsolutePath()));
                 setResult(Activity.RESULT_OK, intent);
                 finish();
                 return true;
@@ -310,7 +311,7 @@ public class FolderPickerActivity extends SyncthingActivity
 
     /**
      * Goes up a directory, up to the list of roots if there are multiple roots.
-     *
+     * <p>
      * If we already are in the list of roots, or if we are directly in the only
      * root folder, we cancel.
      */

--- a/src/main/java/com/nutomic/syncthingandroid/activities/FolderPickerActivity.java
+++ b/src/main/java/com/nutomic/syncthingandroid/activities/FolderPickerActivity.java
@@ -13,6 +13,7 @@ import android.os.Environment;
 import android.os.IBinder;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v4.content.ContextCompat;
 import android.text.TextUtils;
 import android.util.Log;
@@ -32,6 +33,8 @@ import com.google.common.collect.Sets;
 import com.nutomic.syncthingandroid.R;
 import com.nutomic.syncthingandroid.SyncthingApp;
 import com.nutomic.syncthingandroid.service.SyncthingService;
+
+import org.w3c.dom.Text;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -67,22 +70,15 @@ public class FolderPickerActivity extends SyncthingActivity
      */
     private File mLocation;
 
-    public static Intent createIntent(Context context, String currentPath) {
+    public static Intent createIntent(Context context, String initialDirectory, @Nullable String rootDirectory) {
         Intent intent = new Intent(context, FolderPickerActivity.class);
 
-        if (!TextUtils.isEmpty(currentPath)) {
-            intent.putExtra(FolderPickerActivity.EXTRA_INITIAL_DIRECTORY, currentPath);
+        if (!TextUtils.isEmpty(initialDirectory)) {
+            intent.putExtra(EXTRA_INITIAL_DIRECTORY, initialDirectory);
         }
 
-        return intent;
-    }
-
-    //Creates intent with a specified root directory that is used to limit what directories the user can browse.
-    public static Intent createIntentWithRootDir(Context context, String currentPath, String rootDir) {
-        Intent intent = createIntent(context, currentPath);
-
-        if(!TextUtils.isEmpty(rootDir)) {
-            intent.putExtra(EXTRA_ROOT_DIRECTORY, rootDir);
+        if (!TextUtils.isEmpty(rootDirectory)) {
+            intent.putExtra(EXTRA_ROOT_DIRECTORY, rootDirectory);
         }
 
         return intent;
@@ -148,7 +144,6 @@ public class FolderPickerActivity extends SyncthingActivity
                 Collections.addAll(roots, new File("/storage/").listFiles());
                 roots.add(new File("/"));
             }
-
         }
         // Remove any invalid directories.
         Iterator<File> it = roots.iterator();
@@ -158,6 +153,7 @@ public class FolderPickerActivity extends SyncthingActivity
                 it.remove();
             }
         }
+
         mRootsAdapter.addAll(Sets.newTreeSet(roots));
     }
 

--- a/src/main/java/com/nutomic/syncthingandroid/activities/FolderPickerActivity.java
+++ b/src/main/java/com/nutomic/syncthingandroid/activities/FolderPickerActivity.java
@@ -11,9 +11,11 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.IBinder;
+import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.v4.content.ContextCompat;
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -48,6 +50,9 @@ public class FolderPickerActivity extends SyncthingActivity
     private static final String EXTRA_INITIAL_DIRECTORY =
             "com.nutomic.syncthingandroid.activities.FolderPickerActivity.INITIAL_DIRECTORY";
 
+    public static final String EXTRA_ROOT_DIRECTORY =
+            "com.nutomic.syncthingandroid.activities.FolderPickerActivity.ROT_DIRECTORY";
+
     public static final String EXTRA_RESULT_DIRECTORY =
             "com.nutomic.syncthingandroid.activities.FolderPickerActivity.RESULT_DIRECTORY";
 
@@ -56,7 +61,6 @@ public class FolderPickerActivity extends SyncthingActivity
     private ListView mListView;
     private FileAdapter mFilesAdapter;
     private RootsAdapter mRootsAdapter;
-    @Inject SharedPreferences mPreferences;
 
     /**
      * Location of null means that the list of roots is displayed.
@@ -68,6 +72,17 @@ public class FolderPickerActivity extends SyncthingActivity
 
         if (!TextUtils.isEmpty(currentPath)) {
             intent.putExtra(FolderPickerActivity.EXTRA_INITIAL_DIRECTORY, currentPath);
+        }
+
+        return intent;
+    }
+
+    //Creates intent with a specified root directory that is used to limit what directories the user can browse.
+    public static Intent createIntentWithRootDir(Context context, String currentPath, String rootDir) {
+        Intent intent = createIntent(context, currentPath);
+
+        if(!TextUtils.isEmpty(rootDir)) {
+            intent.putExtra(EXTRA_ROOT_DIRECTORY, rootDir);
         }
 
         return intent;
@@ -101,7 +116,8 @@ public class FolderPickerActivity extends SyncthingActivity
     }
 
     /**
-     * Reads available storage devices/folders from various APIs and inserts them into
+     * If a root directory is specefied it is added to {@link #mRootsAdapter} otherwise
+     * all available storage devices/folders from various APIs are inserted into
      * {@link #mRootsAdapter}.
      */
     @SuppressLint("NewApi")
@@ -111,22 +127,29 @@ public class FolderPickerActivity extends SyncthingActivity
             roots.addAll(Arrays.asList(getExternalFilesDirs(null)));
             roots.remove(getExternalFilesDir(null));
         }
-        roots.add(Environment.getExternalStorageDirectory());
-        roots.add(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MUSIC));
-        roots.add(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES));
-        roots.add(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES));
-        roots.add(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS));
-        roots.add(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DCIM));
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-            roots.add(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS));
-        }
 
-        // Add paths that might not be accessible to Syncthing.
-        if (mPreferences.getBoolean("advanced_folder_picker", false)) {
-            Collections.addAll(roots, new File("/storage/").listFiles());
-            roots.add(new File("/"));
-        }
+        String rootDir = getIntent().getStringExtra(EXTRA_ROOT_DIRECTORY);
+        if (getIntent().hasExtra(EXTRA_ROOT_DIRECTORY) && !TextUtils.isEmpty(rootDir)) {
+            roots.add(new File(rootDir));
+        } else {
+            roots.add(Environment.getExternalStorageDirectory());
+            roots.add(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MUSIC));
+            roots.add(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES));
+            roots.add(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES));
+            roots.add(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS));
+            roots.add(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DCIM));
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+                roots.add(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS));
+            }
 
+            // Add paths that might not be accessible to Syncthing.
+            SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(this);
+            if (sp.getBoolean("advanced_folder_picker", false)) {
+                Collections.addAll(roots, new File("/storage/").listFiles());
+                roots.add(new File("/"));
+            }
+
+        }
         // Remove any invalid directories.
         Iterator<File> it = roots.iterator();
         while (it.hasNext()) {

--- a/src/main/java/com/nutomic/syncthingandroid/activities/FolderPickerActivity.java
+++ b/src/main/java/com/nutomic/syncthingandroid/activities/FolderPickerActivity.java
@@ -51,7 +51,7 @@ public class FolderPickerActivity extends SyncthingActivity
             "com.nutomic.syncthingandroid.activities.FolderPickerActivity.INITIAL_DIRECTORY";
 
     public static final String EXTRA_ROOT_DIRECTORY =
-            "com.nutomic.syncthingandroid.activities.FolderPickerActivity.ROT_DIRECTORY";
+            "com.nutomic.syncthingandroid.activities.FolderPickerActivity.ROOT_DIRECTORY";
 
     public static final String EXTRA_RESULT_DIRECTORY =
             "com.nutomic.syncthingandroid.activities.FolderPickerActivity.RESULT_DIRECTORY";
@@ -116,7 +116,7 @@ public class FolderPickerActivity extends SyncthingActivity
     }
 
     /**
-     * If a root directory is specefied it is added to {@link #mRootsAdapter} otherwise
+     * If a root directory is specified it is added to {@link #mRootsAdapter} otherwise
      * all available storage devices/folders from various APIs are inserted into
      * {@link #mRootsAdapter}.
      */

--- a/src/main/java/com/nutomic/syncthingandroid/activities/ShareActivity.java
+++ b/src/main/java/com/nutomic/syncthingandroid/activities/ShareActivity.java
@@ -108,6 +108,7 @@ public class ShareActivity extends StateDialogActivity
 
         Button mShareButton = (Button) findViewById(R.id.share_button);
         Button mCancelButton = (Button) findViewById(R.id.cancel_button);
+        Button browseButton = (Button) findViewById(R.id.browse_button);
         EditText mShareName = (EditText) findViewById(R.id.name);
         TextView mShareTitle = (TextView) findViewById(R.id.namesTitle);
 
@@ -167,15 +168,16 @@ public class ShareActivity extends StateDialogActivity
             }
         });
 
-        mSubDirectoryTextView.setText(getSavedSubDirectory());
-        mSubDirectoryTextView.setOnClickListener(view -> {
+        browseButton.setOnClickListener(view -> {
             Folder folder = (Folder) mFoldersSpinner.getSelectedItem();
             File initialDirectory = new File(folder.path, getSavedSubDirectory());
             startActivityForResult(FolderPickerActivity.createIntent(getApplicationContext(),
                     initialDirectory.getAbsolutePath(), folder.path),
                     FolderPickerActivity.DIRECTORY_REQUEST_CODE);
         });
+
         mCancelButton.setOnClickListener(view -> finish());
+        mSubDirectoryTextView.setText(getSavedSubDirectory());
     }
 
     /**
@@ -258,6 +260,9 @@ public class ShareActivity extends StateDialogActivity
         return displayName;
     }
 
+    /**
+     * Get the previously selected sub directory for the currently selected Syncthing folder.
+     */
     private String getSavedSubDirectory() {
         Folder selectedFolder = (Folder) mFoldersSpinner.getSelectedItem();
         String savedSubDirectory = "";
@@ -360,9 +365,10 @@ public class ShareActivity extends StateDialogActivity
             if (!folderDirectory.endsWith("/")) {
                 folderDirectory += "/";
             }
-            String subDirectory = data.getStringExtra(FolderPickerActivity.EXTRA_RESULT_DIRECTORY);
+
+            String subDirectory = data.getStringExtra(FolderPickerActivity.EXTRA_RESULT_DIRECTORY) + "/";
             //Remove the parent directory from the string, so it is only the Sub directory that is displayed to the user.
-            subDirectory = (subDirectory).replace(folderDirectory.substring(0, folderDirectory.length()-1), "");
+            subDirectory = (subDirectory).replace(folderDirectory.substring(0, folderDirectory.length()), "");
 
             mSubDirectoryTextView.setText(subDirectory);
 

--- a/src/main/java/com/nutomic/syncthingandroid/activities/ShareActivity.java
+++ b/src/main/java/com/nutomic/syncthingandroid/activities/ShareActivity.java
@@ -3,7 +3,6 @@ package com.nutomic.syncthingandroid.activities;
 import android.app.ProgressDialog;
 import android.content.ContentResolver;
 import android.content.Intent;
-import android.content.SharedPreferences;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.AsyncTask;
@@ -18,7 +17,6 @@ import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.EditText;
-import android.widget.ImageButton;
 import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -39,11 +37,10 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Shares incoming files to syncthing folders.
- *
+ * <p>
  * {@link #getDisplayNameForUri} and {@link #getDisplayNameFromContentResolver} are taken from
  * ownCloud Android {@see https://github.com/owncloud/android/blob/79664304fdb762b2e04f1ac505f50d0923ddd212/src/com/owncloud/android/utils/UriUtils.java#L193}
  */
@@ -70,7 +67,7 @@ public class ShareActivity extends StateDialogActivity
         int folderIndex = 0;
         String savedFolderId = PreferenceManager.getDefaultSharedPreferences(this)
                 .getString(PREF_PREVIOUSLY_SELECTED_SYNCTHING_FOLDER, "");
-        for (Folder folder: folders) {
+        for (Folder folder : folders) {
             if (folder.id.equals(savedFolderId)) {
                 folderIndex = folders.indexOf(folder);
                 break;
@@ -106,14 +103,14 @@ public class ShareActivity extends StateDialogActivity
 
         registerOnServiceConnectedListener(this);
 
-        Button mShareButton = (Button) findViewById(R.id.share_button);
-        Button mCancelButton = (Button) findViewById(R.id.cancel_button);
-        Button browseButton = (Button) findViewById(R.id.browse_button);
-        EditText mShareName = (EditText) findViewById(R.id.name);
-        TextView mShareTitle = (TextView) findViewById(R.id.namesTitle);
+        Button mShareButton = findViewById(R.id.share_button);
+        Button mCancelButton = findViewById(R.id.cancel_button);
+        Button browseButton = findViewById(R.id.browse_button);
+        EditText mShareName = findViewById(R.id.name);
+        TextView mShareTitle = findViewById(R.id.namesTitle);
 
-        mSubDirectoryTextView = (TextView) findViewById(R.id.sub_directory_Textview);
-        mFoldersSpinner = (Spinner) findViewById(R.id.folders);
+        mSubDirectoryTextView = findViewById(R.id.sub_directory_Textview);
+        mFoldersSpinner = findViewById(R.id.folders);
 
         // TODO: add support for EXTRA_TEXT (notes, memos sharing)
         ArrayList<Uri> extrasToCopy = new ArrayList<>();
@@ -269,7 +266,7 @@ public class ShareActivity extends StateDialogActivity
 
         if (selectedFolder != null) {
             savedSubDirectory = PreferenceManager.getDefaultSharedPreferences(this)
-                    .getString(PREF_FOLDER_SAVED_SUBDIRECTORY+selectedFolder.id, "");
+                    .getString(PREF_FOLDER_SAVED_SUBDIRECTORY + selectedFolder.id, "");
         }
 
         return savedSubDirectory;
@@ -329,10 +326,10 @@ public class ShareActivity extends StateDialogActivity
         protected void onPostExecute(Boolean isError) {
             Util.dismissDialogSafe(mProgress, ShareActivity.this);
             Toast.makeText(ShareActivity.this, mIgnored > 0 ?
-                    getResources().getQuantityString(R.plurals.copy_success_partially, mCopied,
-                            mCopied, mFolder.label, mIgnored) :
-                    getResources().getQuantityString(R.plurals.copy_success, mCopied, mCopied,
-                            mFolder.label),
+                            getResources().getQuantityString(R.plurals.copy_success_partially, mCopied,
+                                    mCopied, mFolder.label, mIgnored) :
+                            getResources().getQuantityString(R.plurals.copy_success, mCopied, mCopied,
+                                    mFolder.label),
                     Toast.LENGTH_LONG).show();
             if (isError) {
                 Toast.makeText(ShareActivity.this, getString(R.string.copy_exception),
@@ -358,23 +355,15 @@ public class ShareActivity extends StateDialogActivity
         super.onActivityResult(requestCode, resultCode, data);
         if (requestCode == FolderPickerActivity.DIRECTORY_REQUEST_CODE && resultCode == RESULT_OK) {
             Folder selectedFolder = (Folder) mFoldersSpinner.getSelectedItem();
-            String folderDirectory = selectedFolder.path;
-            //The folder paths are not entirely consistent in terms of what character they end with,
-            //that is why a / is added if it is missing so it can be used to cut the corresponding part
-            //from the subDirectory string, so only the sub directory is displayed.
-            if (!folderDirectory.endsWith("/")) {
-                folderDirectory += "/";
-            }
-
-            String subDirectory = data.getStringExtra(FolderPickerActivity.EXTRA_RESULT_DIRECTORY) + "/";
+            String folderDirectory = Util.formatPath(selectedFolder.path);
+            String subDirectory = data.getStringExtra(FolderPickerActivity.EXTRA_RESULT_DIRECTORY);
             //Remove the parent directory from the string, so it is only the Sub directory that is displayed to the user.
-            subDirectory = (subDirectory).replace(folderDirectory.substring(0, folderDirectory.length()), "");
-
+            subDirectory = subDirectory.replace(folderDirectory, "");
             mSubDirectoryTextView.setText(subDirectory);
 
-           PreferenceManager.getDefaultSharedPreferences(this)
-                   .edit().putString(PREF_FOLDER_SAVED_SUBDIRECTORY+selectedFolder.id, subDirectory)
-                   .apply();
+            PreferenceManager.getDefaultSharedPreferences(this)
+                    .edit().putString(PREF_FOLDER_SAVED_SUBDIRECTORY + selectedFolder.id, subDirectory)
+                    .apply();
         }
     }
 }

--- a/src/main/java/com/nutomic/syncthingandroid/activities/ShareActivity.java
+++ b/src/main/java/com/nutomic/syncthingandroid/activities/ShareActivity.java
@@ -66,7 +66,7 @@ public class ShareActivity extends StateDialogActivity
 
         List<Folder> folders = getApi().getFolders();
 
-        //Get the index of the previously selected folder.
+        // Get the index of the previously selected folder.
         int folderIndex = 0;
         String savedFolderId = getSharedPreferences(SHARED_PREFS_SAVED_DIRECTORIES, MODE_PRIVATE)
                 .getString(PREF_PREVIOUSLY_SELECTED_SYNCTHING_FOLDER, "");

--- a/src/main/java/com/nutomic/syncthingandroid/fragments/dialog/StaggeredVersioningFragment.java
+++ b/src/main/java/com/nutomic/syncthingandroid/fragments/dialog/StaggeredVersioningFragment.java
@@ -65,7 +65,7 @@ public class StaggeredVersioningFragment extends Fragment {
 
         mPathView.setText(currentPath);
         mPathView.setOnClickListener(view ->
-            startActivityForResult(FolderPickerActivity.createIntent(getContext(), currentPath), FolderPickerActivity.DIRECTORY_REQUEST_CODE));
+            startActivityForResult(FolderPickerActivity.createIntent(getContext(), currentPath, null), FolderPickerActivity.DIRECTORY_REQUEST_CODE));
     }
 
     @Override

--- a/src/main/java/com/nutomic/syncthingandroid/service/RestApi.java
+++ b/src/main/java/com/nutomic/syncthingandroid/service/RestApi.java
@@ -3,6 +3,7 @@ package com.nutomic.syncthingandroid.service;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.preference.PreferenceManager;
 import android.util.Log;
 
 import com.google.common.base.Objects;
@@ -18,6 +19,7 @@ import com.google.gson.JsonParser;
 import com.nutomic.syncthingandroid.BuildConfig;
 import com.nutomic.syncthingandroid.SyncthingApp;
 import com.nutomic.syncthingandroid.activities.RestartActivity;
+import com.nutomic.syncthingandroid.activities.ShareActivity;
 import com.nutomic.syncthingandroid.http.GetRequest;
 import com.nutomic.syncthingandroid.http.PostConfigRequest;
 import com.nutomic.syncthingandroid.http.PostScanRequest;
@@ -228,6 +230,10 @@ public class RestApi implements SyncthingService.OnWebGuiAvailableListener,
     public void removeFolder(String id) {
         removeFolderInternal(id);
         sendConfig();
+        // Remove saved data from share activity for this folder.
+        PreferenceManager.getDefaultSharedPreferences(mContext).edit()
+                .remove(ShareActivity.PREF_FOLDER_SAVED_SUBDIRECTORY+id)
+                .apply();
     }
 
     private void removeFolderInternal(String id) {

--- a/src/main/java/com/nutomic/syncthingandroid/util/Util.java
+++ b/src/main/java/com/nutomic/syncthingandroid/util/Util.java
@@ -15,6 +15,7 @@ import com.nutomic.syncthingandroid.R;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.File;
 import java.text.DecimalFormat;
 
 import eu.chainfire.libsuperuser.Shell;
@@ -42,7 +43,7 @@ public class Util {
 
     /**
      * Converts a number of bytes to a human readable file size (eg 3.5 GiB).
-     *
+     * <p>
      * Based on http://stackoverflow.com/a/5599842
      */
     public static String readableFileSize(Context context, long bytes) {
@@ -56,7 +57,7 @@ public class Util {
     /**
      * Converts a number of bytes to a human readable transfer rate in bytes per second
      * (eg 100 KiB/s).
-     *
+     * <p>
      * Based on http://stackoverflow.com/a/5599842
      */
     public static String readableTransferRate(Context context, long bits) {
@@ -69,13 +70,14 @@ public class Util {
     }
 
     /**
+     * <<<<<<< HEAD
      * Normally an application's data directory is only accessible by the corresponding application.
      * Therefore, every file and directory is owned by an application's user and group. When running Syncthing as root,
      * it writes to the application's data directory. This leaves files and directories behind which are owned by root having 0600.
      * Moreover, those acitons performed as root changes a file's type in terms of SELinux.
      * A subsequent start of Syncthing will fail due to insufficient permissions.
      * Hence, this method fixes the owner, group and the files' type of the data directory.
-     * 
+     *
      * @return true if the operation was successfully performed. False otherwise.
      */
     public static boolean fixAppDataPermissions(Context context) {
@@ -135,5 +137,15 @@ public class Util {
             return;
 
         dialog.dismiss();
+    }
+
+    /**
+     * Format a path properly.
+     *
+     * @param path String containing the path that needs formatting.
+     * @return formatted file path as a string.
+     */
+    public static String formatPath(String path) {
+        return new File(path).toURI().normalize().getPath();
     }
 }

--- a/src/main/res/layout/activity_share.xml
+++ b/src/main/res/layout/activity_share.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     tools:context="com.nutomic.syncthingandroid.activities.ShareActivity"
     android:id="@+id/drawer_layout"
@@ -57,7 +58,9 @@
                 android:layout_below="@+id/folder_title"
                 android:layout_alignParentLeft="true"
                 android:layout_alignParentStart="true"
-                android:layout_marginTop="8dp" />
+                android:layout_marginTop="8dp"
+                android:layout_alignParentRight="true"
+                android:layout_alignParentEnd="true" />
 
             <Button
                 android:id="@+id/share_button"
@@ -85,6 +88,31 @@
                 android:layout_toStartOf="@+id/share_button"
                 android:layout_marginRight="14dp"
                 android:layout_marginEnd="14dp" />
+
+            <TextView
+                android:text="@string/sub_folder"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:id="@+id/sub_folder_title"
+                android:layout_below="@+id/folders"
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentStart="true"
+                android:layout_marginTop="8dp" />
+
+            <TextView
+                android:id="@+id/sub_directory_Textview"
+                style="@style/Widget.Syncthing.TextView.Label.Details"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:drawableLeft="@drawable/ic_folder_black_24dp"
+                android:drawableStart="@drawable/ic_folder_black_24dp"
+                android:focusable="true"
+                android:hint="browse"
+                android:layout_below="@+id/sub_folder_title"
+                android:layout_alignStart="@id/folders"
+                android:layout_alignEnd="@id/folders"
+                android:layout_alignLeft="@id/folders"
+                android:layout_alignRight="@id/folders" />
 
         </RelativeLayout>
     </LinearLayout>

--- a/src/main/res/layout/activity_share.xml
+++ b/src/main/res/layout/activity_share.xml
@@ -104,15 +104,25 @@
                 style="@style/Widget.Syncthing.TextView.Label.Details"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:focusable="true"
+                android:hint="@string/no_sub_folder_is_selected"
                 android:drawableLeft="@drawable/ic_folder_black_24dp"
                 android:drawableStart="@drawable/ic_folder_black_24dp"
-                android:focusable="true"
-                android:hint="browse"
                 android:layout_below="@+id/sub_folder_title"
                 android:layout_alignStart="@id/folders"
-                android:layout_alignEnd="@id/folders"
                 android:layout_alignLeft="@id/folders"
-                android:layout_alignRight="@id/folders" />
+                android:layout_toLeftOf="@+id/browse_button"
+                android:layout_toStartOf="@+id/browse_button" />
+
+            <Button
+                android:id="@+id/browse_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/browse"
+                android:layout_alignBottom="@+id/sub_directory_Textview"
+                android:layout_alignParentRight="true"
+                android:layout_alignParentEnd="true"
+                android:layout_alignTop="@+id/sub_directory_Textview" />
 
         </RelativeLayout>
     </LinearLayout>

--- a/src/main/res/layout/activity_share.xml
+++ b/src/main/res/layout/activity_share.xml
@@ -1,20 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    tools:context="com.nutomic.syncthingandroid.activities.ShareActivity"
     android:id="@+id/drawer_layout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:fillViewport="true"
+    android:orientation="vertical"
+    tools:context="com.nutomic.syncthingandroid.activities.ShareActivity">
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:orientation="vertical">
 
         <include layout="@layout/widget_toolbar" />
 
-        <RelativeLayout
+        <android.support.constraint.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:orientation="vertical"
@@ -24,106 +26,137 @@
             android:paddingTop="8dp">
 
             <TextView
+                android:id="@+id/namesTitle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:id="@+id/namesTitle"
-                android:layout_alignParentLeft="true"
-                android:layout_alignParentStart="true"
-                android:layout_marginTop="8dp" />
+                android:layout_marginLeft="8dp"
+                android:layout_marginStart="8dp"
+                android:layout_marginTop="8dp"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
 
             <EditText
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:ems="10"
                 android:id="@+id/name"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                android:layout_marginEnd="8dp"
+                android:layout_marginLeft="8dp"
+                android:layout_marginRight="8dp"
+                android:layout_marginStart="8dp"
+                android:layout_marginTop="8dp"
+                android:ems="10"
                 android:inputType="text|textMultiLine"
-                android:layout_below="@+id/namesTitle"
-                android:layout_alignParentLeft="true"
-                android:layout_alignParentStart="true" />
+                app:layout_constraintBottom_toTopOf="@+id/folders"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/namesTitle"
+                app:layout_constraintVertical_bias="0.0" />
 
             <TextView
-                android:text="@string/folder_title"
+                android:id="@+id/folder_title"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:id="@+id/folder_title"
-                android:layout_below="@+id/name"
-                android:layout_alignParentLeft="true"
-                android:layout_alignParentStart="true"
-                android:layout_marginTop="8dp" />
+                android:layout_marginLeft="8dp"
+                android:layout_marginStart="8dp"
+                android:layout_marginTop="7dp"
+                android:text="@string/folder_title"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/name" />
 
             <Spinner
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
                 android:id="@+id/folders"
-                android:layout_below="@+id/folder_title"
-                android:layout_alignParentLeft="true"
-                android:layout_alignParentStart="true"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="8dp"
+                android:layout_marginLeft="8dp"
+                android:layout_marginRight="8dp"
+                android:layout_marginStart="8dp"
                 android:layout_marginTop="8dp"
-                android:layout_alignParentRight="true"
-                android:layout_alignParentEnd="true" />
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/folder_title" />
 
             <Button
                 android:id="@+id/share_button"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/save_title"
+                android:layout_marginBottom="8dp"
+                android:layout_marginEnd="8dp"
+                android:layout_marginRight="-8dp"
+                android:layout_marginTop="8dp"
                 android:background="?android:selectableItemBackground"
+                android:minWidth="60dip"
+                android:text="@string/save_title"
                 android:textColor="@color/accent"
-                android:layout_alignParentBottom="true"
-                android:layout_alignParentRight="true"
-                android:layout_alignParentEnd="true"
                 android:textSize="14sp"
-                android:minWidth="60dip" />
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/browse_button"
+                app:layout_constraintVertical_bias="0.965" />
 
             <Button
                 android:id="@+id/cancel_button"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/cancel_title"
+                android:layout_marginBottom="8dp"
+                android:layout_marginEnd="8dp"
+                android:layout_marginLeft="8dp"
+                android:layout_marginRight="8dp"
+                android:layout_marginStart="8dp"
+                android:layout_marginTop="8dp"
                 android:background="?android:selectableItemBackground"
-                android:textColor="@color/accent"
                 android:minWidth="50dip"
-                android:layout_alignParentBottom="true"
-                android:layout_toLeftOf="@+id/share_button"
-                android:layout_toStartOf="@+id/share_button"
-                android:layout_marginRight="14dp"
-                android:layout_marginEnd="14dp" />
+                android:text="@string/cancel_title"
+                android:textColor="@color/accent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintHorizontal_bias="0.951"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintRight_toLeftOf="@+id/share_button"
+                app:layout_constraintTop_toBottomOf="@+id/sub_directory_Textview"
+                app:layout_constraintVertical_bias="0.964" />
 
             <TextView
-                android:text="@string/sub_folder"
+                android:id="@+id/sub_folder_title"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:id="@+id/sub_folder_title"
-                android:layout_below="@+id/folders"
-                android:layout_alignParentLeft="true"
-                android:layout_alignParentStart="true"
-                android:layout_marginTop="8dp" />
+                android:layout_marginLeft="8dp"
+                android:layout_marginStart="8dp"
+                android:layout_marginTop="8dp"
+                android:text="@string/sub_folder"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/folders" />
 
             <TextView
                 android:id="@+id/sub_directory_Textview"
                 style="@style/Widget.Syncthing.TextView.Label.Details"
-                android:layout_width="match_parent"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:focusable="true"
-                android:hint="@string/no_sub_folder_is_selected"
+                android:layout_marginLeft="8dp"
+                android:layout_marginStart="8dp"
+                android:layout_marginTop="6dp"
                 android:drawableLeft="@drawable/ic_folder_black_24dp"
                 android:drawableStart="@drawable/ic_folder_black_24dp"
-                android:layout_below="@+id/sub_folder_title"
-                android:layout_alignStart="@id/folders"
-                android:layout_alignLeft="@id/folders"
-                android:layout_toLeftOf="@+id/browse_button"
-                android:layout_toStartOf="@+id/browse_button" />
+                android:focusable="true"
+                android:hint="@string/no_sub_folder_is_selected"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintRight_toLeftOf="@+id/browse_button"
+                app:layout_constraintTop_toBottomOf="@+id/sub_folder_title" />
 
             <Button
                 android:id="@+id/browse_button"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+                android:layout_width="88dp"
+                android:layout_height="48dp"
+                android:layout_marginEnd="8dp"
+                android:layout_marginLeft="8dp"
+                android:layout_marginRight="8dp"
                 android:text="@string/browse"
-                android:layout_alignBottom="@+id/sub_directory_Textview"
-                android:layout_alignParentRight="true"
-                android:layout_alignParentEnd="true"
-                android:layout_alignTop="@+id/sub_directory_Textview" />
+                app:layout_constraintBottom_toBottomOf="@+id/sub_directory_Textview"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/sub_directory_Textview" />
 
-        </RelativeLayout>
+        </android.support.constraint.ConstraintLayout>
     </LinearLayout>
-</android.support.v4.widget.DrawerLayout>
+</ScrollView>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -627,5 +627,7 @@ Please report any problems you encounter via Github.</string>
 
     <!-- error message if the deviceID/QRCode dialog for some reason cannot be displayed.-->
     <string name="could_not_access_deviceid">Could not access device ID.</string>
+    <string name="browse">Browse</string>
+    <string name="no_sub_folder_is_selected">No sub folder is selected</string>
 
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -501,6 +501,9 @@ Please report any problems you encounter via Github.</string>
         <item quantity="other">Files List</item>
     </plurals>
 
+    <!-- Sub Folder title -->
+    <string name="sub_folder">Sub folder</string>
+
     <!-- SyncthingService -->
 
 


### PR DESCRIPTION
Changes:
Added Subdirectory browsing
The previously selected folder is remembered.
The subdirectory is remembered for each Syncthing folder.
The saved subdirectory in the shared preferences is deleted when the corresponding folder is deleted from Syncthing.
The root directory of the FolderPickerActivity is set to the synced folder, so the user can only choose a sub folder within the folder that is being synced.
TheFolderPickerActivity was modified in order to allow for a custom root directory to be set.

Example with no sub folder selected:
![screenshot_20170821-141950](https://user-images.githubusercontent.com/10332534/29525503-2c9d2108-8693-11e7-8ff5-babc06707aee.png)

Example with a sub folder selected:
![screenshot_20170821-162521](https://user-images.githubusercontent.com/10332534/29525521-3fc21eb4-8693-11e7-8796-d72706a6d9ed.png)



