### PR TITLE
Changed misleading title of sttrace option

### DIFF
--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -210,7 +210,7 @@ Bitte melden Sie auftretende Probleme via Github.</string>
   <!--Toast shown after config was successfully imported-->
   <string name="config_import_failed">Import fehlgeschlagen, Dateien werden in %1$s erwartet</string>
   <!--Title for the preference to set STTRACE parameters-->
-  <string name="sttrace_title">Fehlersuchoptionen</string>
+  <string name="sttrace_title">STTRACE Optionen</string>
   <!--Toast after entering invalid STTRACE params-->
   <string name="toast_invalid_sttrace" tools:ignore="TypographyDashes">Nur 0-9, a-z und \',\' sind erlaubt in STTRACE Optionen</string>
   <!--Title for the preference to reset Syncthing indexes-->

--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -210,7 +210,7 @@ Bitte melden Sie auftretende Probleme via Github.</string>
   <!--Toast shown after config was successfully imported-->
   <string name="config_import_failed">Import fehlgeschlagen, Dateien werden in %1$s erwartet</string>
   <!--Title for the preference to set STTRACE parameters-->
-  <string name="sttrace_title">STTRACE Optionen</string>
+  <string name="sttrace_title">Fehlersuchoptionen</string>
   <!--Toast after entering invalid STTRACE params-->
   <string name="toast_invalid_sttrace" tools:ignore="TypographyDashes">Nur 0-9, a-z und \',\' sind erlaubt in STTRACE Optionen</string>
   <!--Title for the preference to reset Syncthing indexes-->

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -349,7 +349,7 @@ Please report any problems you encounter via Github.</string>
     <string name="config_import_failed">Config import failed, make sure files are in %1$s</string>
 
     <!-- Title for the preference to set STTRACE parameters -->
-    <string name="sttrace_title">Debug Options</string>
+    <string name="sttrace_title">STTRACE Options</string>
 
     <string name="environment_variables">Environment variables</string>
 


### PR DESCRIPTION
The sttrace preference field just takes a list of facilities
as an input (https://docs.syncthing.net/dev/debugging.html).
Calling it 'Debug Options' might be misleading since Syncthing
offers way more debugging options than just sttrace.
Naming it 'STTRACE options' makes it clear for the user what
he or she should enter.