### PR TITLE
Fix web UI being reloaded on orientation changes

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -46,7 +46,8 @@
         <activity
             android:name=".activities.WebGuiActivity"
             android:label="@string/web_gui_title"
-            android:parentActivityName=".activities.MainActivity">
+            android:parentActivityName=".activities.MainActivity"
+            android:configChanges="keyboardHidden|orientation|screenSize">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".activities.MainActivity" />


### PR DESCRIPTION
Declare WebGuiActivity to handle orientation changes (not currently necessary) to prevent the redundant re-creation of the Activity.

See #970 
