### PR TITLE
Fix redundant reload of the web UI

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/WebGuiActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/WebGuiActivity.java
@@ -141,7 +141,21 @@ public class WebGuiActivity extends StateDialogActivity
 
     @Override
     public void onWebGuiAvailable() {
-        mWebView.loadUrl(getService().getWebGuiUrl().toString());
+        final String serviceUrl = getService().getWebGuiUrl().toString();
+        if (!isCurrentUrl(serviceUrl)) {
+            mWebView.loadUrl(serviceUrl);
+        }
+    }
+
+    private boolean isCurrentUrl(final String url) {
+        String currentUrl = mWebView.getUrl();
+        if (currentUrl == null || currentUrl.length() == 0) {
+            return false;
+        }
+        if (currentUrl.endsWith("/")) {
+            currentUrl = currentUrl.substring(0, currentUrl.length() - 1);
+        }
+        return currentUrl.equals(url);
     }
 
     @Override


### PR DESCRIPTION
Don't reload the web UI when resuming the web UI activity if the URL was already loaded.

See #970