### PR TITLE
Fix redundant web UI reload

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/WebGuiActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/WebGuiActivity.java
@@ -141,7 +141,9 @@ public class WebGuiActivity extends StateDialogActivity
 
     @Override
     public void onWebGuiAvailable() {
-        mWebView.loadUrl(getService().getWebGuiUrl().toString());
+        if (mWebView.getUrl() == null) {
+            mWebView.loadUrl(getService().getWebGuiUrl().toString());
+        }
     }
 
     @Override


### PR DESCRIPTION
Don't reload the web UI if it was already loaded.
Follow up on #988, see #970.