### PR TITLE
MainActivity.java: Don't show Usage Reporting dialog if aready decided

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/MainActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/MainActivity.java
@@ -110,7 +110,7 @@ public class MainActivity extends StateDialogActivity
                 mDrawerFragment.requestGuiUpdate();
                 getApi().getSystemInfo(systemInfo -> {
                     if (new Date().getTime() > getFirstStartTime() + USAGE_REPORTING_DIALOG_DELAY &&
-                            getApi().getOptions().isUsageReportingDecided(systemInfo.urVersionMax)) {
+                            !getApi().getOptions().isUsageReportingDecided(systemInfo.urVersionMax)) {
                         showUsageReportingDialog();
                     }
                 });


### PR DESCRIPTION
Fix the condition to show usage reporting prompt. (Fixes: https://github.com/syncthing/syncthing-android/issues/1009)

I don't have access to Android Studio atm, so I haven't actually tested it - keep this in mind.