### PR TITLE
Request ACCESS_COARSE_LOCATION on Android 8.1 (fixes #999)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,8 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.READ_SYNC_SETTINGS" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
+    <!-- ACCESS_COARSE_LOCATION is required to get WiFi's SSID on 8.1 -->
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <application
         android:allowBackup="false"

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -1,5 +1,6 @@
 package com.nutomic.syncthingandroid.activities;
 
+import android.Manifest;
 import android.app.AlertDialog;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -13,6 +14,7 @@ import android.preference.ListPreference;
 import android.preference.Preference;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceScreen;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.Log;
 import android.widget.Toast;
@@ -47,6 +49,26 @@ public class SettingsActivity extends SyncthingActivity {
         getFragmentManager().beginTransaction()
                 .replace(android.R.id.content, new SettingsFragment())
                 .commit();
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        // On Android 8.1, ACCESS_COARSE_LOCATION is required, see issue #999
+        if (requestCode == Constants.PERM_REQ_ACCESS_COARSE_LOCATION) {
+            for (int i = 0; i < permissions.length; i++) {
+                if (Manifest.permission.ACCESS_COARSE_LOCATION.equals(permissions[i])) {
+                    if (grantResults[i] == PackageManager.PERMISSION_GRANTED) {
+                        this.startService(new Intent(this, SyncthingService.class)
+                                .setAction(SyncthingService.ACTION_REFRESH_NETWORK_INFO));
+                    } else {
+                        new AlertDialog.Builder(this)
+                                .setTitle(R.string.sync_only_wifi_ssids_location_permission_rejected_dialog_title)
+                                .setMessage(R.string.sync_only_wifi_ssids_location_permission_rejected_dialog_content)
+                                .setPositiveButton(android.R.string.ok, null).show();
+                    }
+                }
+            }
+        }
     }
 
     public static class SettingsFragment extends PreferenceFragment

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
@@ -18,6 +18,12 @@ public class Constants {
     public static final String PREF_USE_WAKE_LOCK            = "wakelock_while_binary_running";
 
     /**
+     * On Android 8.1, ACCESS_COARSE_LOCATION is required to access WiFi SSID.
+     * This is the request code used when requesting the permission.
+     */
+    public static final int PERM_REQ_ACCESS_COARSE_LOCATION = 999; // for issue #999
+
+    /**
      * Interval in ms at which the GUI is updated (eg {@link com.nutomic.syncthingandroid.fragments.DrawerFragment}).
      */
     public static final long GUI_UPDATE_INTERVAL = TimeUnit.SECONDS.toMillis(5);

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/DeviceStateHolder.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/DeviceStateHolder.java
@@ -183,6 +183,11 @@ public class DeviceStateHolder implements SharedPreferences.OnSharedPreferenceCh
         }
     }
 
+    public void refreshNetworkInfo() {
+        updateWifiSsid();
+        mListener.onDeviceStateChanged();
+    }
+
     /**
      * Determines if Syncthing should currently run.
      */

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
@@ -48,6 +48,9 @@ public class SyncthingService extends Service {
     public static final String ACTION_RESET =
             "com.nutomic.syncthingandroid.service.SyncthingService.RESET";
 
+    public static final String ACTION_REFRESH_NETWORK_INFO =
+            "com.nutomic.syncthingandroid.service.SyncthingService.REFRESH_NETWORK_INFO";
+
     /**
      * Callback for when the Syncthing web interface becomes first available after service start.
      */
@@ -122,6 +125,8 @@ public class SyncthingService extends Service {
                 new SyncthingRunnable(this, SyncthingRunnable.Command.reset).run();
                 new StartupTask().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
             });
+        } else if (ACTION_REFRESH_NETWORK_INFO.equals(intent.getAction())) {
+            mDeviceStateHolder.refreshNetworkInfo();
         }
         return START_STICKY;
     }

--- a/app/src/main/java/com/nutomic/syncthingandroid/views/WifiSsidPreference.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/views/WifiSsidPreference.java
@@ -1,14 +1,21 @@
 package com.nutomic.syncthingandroid.views;
 
+import android.Manifest;
+import android.app.Activity;
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.net.wifi.WifiConfiguration;
 import android.net.wifi.WifiManager;
+import android.os.Build;
 import android.os.Bundle;
 import android.preference.MultiSelectListPreference;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
 import android.util.AttributeSet;
 import android.widget.Toast;
 
 import com.nutomic.syncthingandroid.R;
+import com.nutomic.syncthingandroid.service.Constants;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -66,6 +73,19 @@ public class WifiSsidPreference extends MultiSelectListPreference {
             super.showDialog(state);
         } else {
             Toast.makeText(getContext(), R.string.sync_only_wifi_ssids_wifi_turn_on_wifi, Toast.LENGTH_LONG).show();
+        }
+
+        // On Android 8.1, ACCESS_COARSE_LOCATION is required, see issue #999
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+            if (ContextCompat.checkSelfPermission(getContext(), Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+                if (getContext() instanceof Activity) {
+                    Activity activity = (Activity) getContext();
+                    ActivityCompat.requestPermissions(activity, new String[] { Manifest.permission.ACCESS_COARSE_LOCATION }, Constants.PERM_REQ_ACCESS_COARSE_LOCATION);
+                    this.getDialog().dismiss(); // wait for result
+                } else {
+                    Toast.makeText(getContext(), R.string.sync_only_wifi_ssids_need_to_grant_location_permission, Toast.LENGTH_LONG).show();
+                }
+            }
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -264,6 +264,11 @@ Please report any problems you encounter via Github.</string>
 
     <string name="sync_only_wifi_ssids_wifi_turn_on_wifi">Please turn on WiFi to select networks.</string>
 
+    <string name="sync_only_wifi_ssids_need_to_grant_location_permission">You need to grant LOCATION permission to use this feature.</string>
+
+    <string name="sync_only_wifi_ssids_location_permission_rejected_dialog_title">Permission required</string>
+    <string name="sync_only_wifi_ssids_location_permission_rejected_dialog_content">Starting with Android 8.1, location access is required to be able to read the WiFi\'s name. You can use this feature only if you grant this permission.</string>
+
     <string name="respect_battery_saving_title">Respect Android battery saving setting</string>
     <string name="respect_battery_saving_summary">Disable Syncthing if battery saving is active</string>
 


### PR DESCRIPTION
As outlined in https://issuetracker.google.com/issues/70795529, accessing the WiFi's SSID on Android 8.1 requires `ACCESS_COARSE_LOCATION`.

This PR adds this permission to the manifest and on Android 8.1+ it requests the permission, if the WiFi SSID preference is selected and the permission has not yet been granted.

In case the permission is rejected, a short explanation is shown.

In case the permission granted, the WiFi's SSID is refreshed via `SyncthingService` and configuration of the restricted SSIDs can resume.