### PR TITLE
Use separate notification channel while monitoring run conditions

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -541,7 +541,8 @@ Please report any problems you encounter via Github.</string>
 
     <string name="notification_crash_text">Click to view logs</string>
 
-    <string name="notifications_persistent_channel">Persistent notification</string>
+    <string name="notifications_persistent_channel">Syncthing active</string>
+    <string name="notification_persistent_waiting_channel">Monitoring run conditions</string>
     <string name="notifications_other_channel">Other notifications</string>
 
     <!-- RestApi -->


### PR DESCRIPTION
As discussed in #998, or #1021, since Android 8.0 we are currently forced to have the service running with foreground priority in order to receive broadcasts. This leads to the "Syncthing is disabled" notification, which is annoying.

Splitting the "Syncthing is active" and "Syncthing is disabled" into two separate notification channels at least allows on 8.0+ to hide or at least make the "Syncthing is disabled" notification less intrusive.

Unfortunately this advantage remains only for 8.0+, so this is not a fix for the issues referenced above.