### PR TITLE
Update build.gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,7 +33,7 @@ android {
     }
     defaultConfig {
         applicationId "com.nutomic.syncthingandroid"
-        minSdkVersion 14
+        minSdkVersion 16
         targetSdkVersion 26
         versionCode 4141
         versionName "0.10.8"


### PR DESCRIPTION
Bump minSdk to 16 as apparently anything below android 4.1 ships a linker that does not support position independent code, which means syncthing crashes once built with NDK.

We could try to build syncthing without PIE, but to be honest, it's easier just to kill support for an 8 year old version.