### PR TITLE
Make current proxy text clearer

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -355,7 +355,7 @@ Please report any problems you encounter via Github.</string>
 
     <!-- Experimental options -->
     <string name="use_proxy">Connect through a proxy</string>
-    <string name="do_not_use_proxy">Do not connect through a proxy</string>
+    <string name="do_not_use_proxy">No proxy configured.</string>
 
     <string name="keep_wakelock_while_binary_running">Keep the CPU awake while Syncthing is running</string>
 


### PR DESCRIPTION
The current one sounds strange `Do not connect through proxy Example <proxy>`, so I setup a proxy to NOT connect? (Yes it got changed when edited...)