### PR TITLE
Fix Android Studio 3.1.3 build-tool warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-27.0.2
+    - build-tools-27.0.3
     - android-27
     - extra-android-m2repository
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 android {
     // Changes to these values need to be reflected in `.travis.yml`
     compileSdkVersion 27
-    buildToolsVersion "27.0.2"
+    buildToolsVersion '27.0.3'
 
     buildTypes.debug.applicationIdSuffix ".debug"
     dataBinding.enabled = true

--- a/build.gradle
+++ b/build.gradle
@@ -2,13 +2,11 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
-        maven {
-            url "https://maven.google.com"
-        }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.3'
         classpath 'com.github.triplet.gradle:play-publisher:1.2.0'
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.15.0'
 
@@ -19,10 +17,8 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
-        maven {
-            url "https://maven.google.com"
-        }
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Fri Jun 08 21:11:25 CEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.5-all.zip


### PR DESCRIPTION
Adjust build-tools version and Gradle version to work with latest Android Studio (3.1.3).