### PR TITLE
Add ext/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ project.properties
 # Gradle wrapper
 gradle/wrapper/gradle/
 gradle/wrapper/gradlew*
+
+# External build artifacts
+ext/


### PR DESCRIPTION
`ext` contains build artifacts from building `go` and `syncthing`.