### PR TITLE
Add randomization to default camera folder name (fixes #1159)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
@@ -51,7 +51,7 @@ public class ConfigXml {
     }
 
     private static final String TAG = "ConfigXml";
-    private static final int DEVICE_ID_APPENDIX_LENGTH = 7;
+    private static final int FOLDER_ID_APPENDIX_LENGTH = 4;
 
     private final Context mContext;
     @Inject SharedPreferences mPreferences;
@@ -306,9 +306,9 @@ public class ConfigXml {
                 .replace(" ", "_")
                 .toLowerCase(Locale.US)
                 .replaceAll("[^a-z0-9_-]", "");
-        String deviceId = deviceModel + "_" + generateRandomString(DEVICE_ID_APPENDIX_LENGTH);
+        String defaultFolderId = deviceModel + "_" + generateRandomString(FOLDER_ID_APPENDIX_LENGTH);
         folder.setAttribute("label", mContext.getString(R.string.default_folder_label));
-        folder.setAttribute("id", mContext.getString(R.string.default_folder_id, deviceId));
+        folder.setAttribute("id", mContext.getString(R.string.default_folder_id, defaultFolderId));
         folder.setAttribute("path", Environment
                 .getExternalStoragePublicDirectory(Environment.DIRECTORY_DCIM).getAbsolutePath());
         folder.setAttribute("type", "readonly");

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Locale;
+import java.util.Random;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -50,6 +51,7 @@ public class ConfigXml {
     }
 
     private static final String TAG = "ConfigXml";
+    private static final int DEVICE_ID_APPENDIX_LENGTH = 7;
 
     private final Context mContext;
     @Inject SharedPreferences mPreferences;
@@ -304,14 +306,28 @@ public class ConfigXml {
                 .replace(" ", "_")
                 .toLowerCase(Locale.US)
                 .replaceAll("[^a-z0-9_-]", "");
+        String deviceId = deviceModel + "_" + generateRandomString(DEVICE_ID_APPENDIX_LENGTH);
         folder.setAttribute("label", mContext.getString(R.string.default_folder_label));
-        folder.setAttribute("id", mContext.getString(R.string.default_folder_id, deviceModel));
+        folder.setAttribute("id", mContext.getString(R.string.default_folder_id, deviceId));
         folder.setAttribute("path", Environment
                 .getExternalStoragePublicDirectory(Environment.DIRECTORY_DCIM).getAbsolutePath());
         folder.setAttribute("type", "readonly");
         folder.setAttribute("fsWatcherEnabled", "true");
         folder.setAttribute("fsWatcherDelayS", "10");
         return true;
+    }
+
+    /**
+     * Generates a random String with a given length
+     */
+    private String generateRandomString(int length) {
+        char[] chars = "abcdefghjkmnpqrstuvwxyz123456789".toCharArray();
+        Random random = new Random();
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < length; ++i) {
+            sb.append(chars[random.nextInt(chars.length)]);
+        }
+        return sb.toString();
     }
 
     /**


### PR DESCRIPTION
Purpose
As it was mentioned in [#1159](https://github.com/syncthing/syncthing-android/issues/1159) it's better not to have a default camera folder's id as it it, because there is a big risk of collisions. It was also discussed, to randomize somehow that id. The reasonable trade off between fully random id and meaningful is to append same short random string to the meaningful id. I appended 7 random characters preceded by under dash.
Testing
Was tested on Android emulator (Nexus 5, Android 7.1.1)