### PR TITLE
build: add gradle.properties to select java version 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The project is translated on [Transifex](https://www.transifex.com/projects/p/sy
 - Android SDK (you can skip this if you are using Android Studio)
 - Android NDK (`$ANDROID_NDK_HOME` should point at the root directory of your NDK)
 - Go (see [here](https://docs.syncthing.net/dev/building.html#prerequisites) for the required version)
+- Java Version 8 (you might need to set `$JAVA_HOME` accordingly)
 
 ### Build instructions
 


### PR DESCRIPTION
Apparently the current default java version on my system is 10, and the resulting error from gradle is totally clear:

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':app'.
> java.lang.NullPointerException (no error message)

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 1s
```

In order to spare other new (and not java-versed) contributors this headache, lets just specify this version.