### PR TITLE
Show reasons for disabled service in notification dialog (fixes #1263)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/model/RunConditionCheckResult.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/model/RunConditionCheckResult.java
@@ -1,0 +1,78 @@
+package com.nutomic.syncthingandroid.model;
+
+import com.nutomic.syncthingandroid.R;
+
+import java.util.Collections;
+import java.util.List;
+
+public class RunConditionCheckResult {
+
+    public enum BlockerReason {
+        ON_BATTERY(R.string.syncthing_disabled_reason_on_battery),
+        ON_CHARGER(R.string.syncthing_disabled_reason_on_charger),
+        POWERSAVING_ENABLED(R.string.syncthing_disabled_reason_powersaving),
+        GLOBAL_SYNC_DISABLED(R.string.syncthing_disabled_reason_android_sync_disabled),
+        WIFI_SSID_NOT_WHITELISTED(R.string.syncthing_disabled_reason_wifi_ssid_not_whitelisted),
+        WIFI_WIFI_IS_METERED(R.string.syncthing_disabled_reason_wifi_is_metered),
+        NO_NETWORK_OR_FLIGHTMODE(R.string.syncthing_disabled_reason_no_network_or_flightmode),
+        NO_MOBILE_CONNECTION(R.string.syncthing_disabled_reason_no_mobile_connection),
+        NO_WIFI_CONNECTION(R.string.syncthing_disabled_reason_no_wifi_connection),
+        NO_ALLOWED_NETWORK(R.string.syncthing_disabled_reason_no_allowed_method);
+
+        private final int resId;
+
+        BlockerReason(int resId) {
+            this.resId = resId;
+        }
+
+        public int getResId() {
+            return resId;
+        }
+    }
+
+    public static final RunConditionCheckResult SHOULD_RUN = new RunConditionCheckResult();
+
+    private final boolean mShouldRun;
+    private final List<BlockerReason> mBlockReasons;
+
+    /**
+     * Use SHOULD_RUN instead.
+     * Note: of course anybody could still construct it by providing an empty list to the other
+     * constructor.
+     */
+    private RunConditionCheckResult() {
+        this(Collections.emptyList());
+    }
+
+    public RunConditionCheckResult(List<BlockerReason> blockReasons) {
+        mBlockReasons = Collections.unmodifiableList(blockReasons);
+        mShouldRun = blockReasons.isEmpty();
+    }
+
+
+    public List<BlockerReason> getBlockReasons() {
+        return mBlockReasons;
+    }
+
+    public boolean isShouldRun() {
+        return mShouldRun;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        RunConditionCheckResult that = (RunConditionCheckResult) o;
+
+        if (mShouldRun != that.mShouldRun) return false;
+        return mBlockReasons.equals(that.mBlockReasons);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = (mShouldRun ? 1 : 0);
+        result = 31 * result + mBlockReasons.hashCode();
+        return result;
+    }
+}

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
@@ -1,33 +1,34 @@
 package com.nutomic.syncthingandroid.service;
 
+import android.Manifest;
 import android.app.Service;
 import android.content.Intent;
-import android.content.pm.PackageManager;
 import android.content.SharedPreferences;
-import android.Manifest;
+import android.content.pm.PackageManager;
 import android.os.AsyncTask;
 import android.os.Handler;
 import android.support.annotation.Nullable;
 import android.support.v4.content.ContextCompat;
 import android.util.Log;
-import android.widget.Toast;
 
 import com.android.PRNGFixes;
-import com.annimon.stream.Stream;
 import com.google.common.io.Files;
 import com.nutomic.syncthingandroid.R;
 import com.nutomic.syncthingandroid.SyncthingApp;
 import com.nutomic.syncthingandroid.http.PollWebGuiAvailableTask;
-import com.nutomic.syncthingandroid.model.Folder;
+import com.nutomic.syncthingandroid.model.RunConditionCheckResult;
 import com.nutomic.syncthingandroid.util.ConfigXml;
 
 import java.io.File;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.inject.Inject;
 
@@ -99,6 +100,10 @@ public class SyncthingService extends Service {
         void onServiceStateChange(State currentState);
     }
 
+    public interface OnRunConditionCheckResultListener {
+        void onRunConditionCheckResultChanged(RunConditionCheckResult result);
+    }
+
     /**
      * Indicates the current state of SyncthingService and of Syncthing itself.
      */
@@ -124,6 +129,7 @@ public class SyncthingService extends Service {
      * {@link onStartCommand}.
      */
     private State mCurrentState = State.DISABLED;
+    private AtomicReference<RunConditionCheckResult> mCurrentCheckResult = new AtomicReference<>(RunConditionCheckResult.SHOULD_RUN);
 
     private ConfigXml mConfig;
     private @Nullable PollWebGuiAvailableTask mPollWebGuiAvailableTask = null;
@@ -136,6 +142,7 @@ public class SyncthingService extends Service {
     private Handler mHandler;
 
     private final HashSet<OnServiceStateChangeListener> mOnServiceStateChangeListeners = new HashSet<>();
+    private final HashSet<OnRunConditionCheckResultListener> mOnRunConditionCheckResultListeners = new HashSet<>();
     private final SyncthingServiceBinder mBinder = new SyncthingServiceBinder(this);
 
     @Inject NotificationHandler mNotificationHandler;
@@ -262,7 +269,13 @@ public class SyncthingService extends Service {
      * function is called to notify this class to run/terminate the syncthing binary.
      * {@link #onServiceStateChange} is called while applying the decision change.
      */
-    private void onUpdatedShouldRunDecision(boolean newShouldRunDecision) {
+    private void onUpdatedShouldRunDecision(RunConditionCheckResult result) {
+        boolean newShouldRunDecision = result.isShouldRun();
+        boolean reasonsChanged = !mCurrentCheckResult.getAndSet(result).equals(result);
+        if (reasonsChanged) {
+            onRunConditionCheckResultChange(result);
+        }
+
         if (newShouldRunDecision != mLastDeterminedShouldRun) {
             Log.i(TAG, "shouldRun decision changed to " + newShouldRunDecision + " according to configured run conditions.");
             mLastDeterminedShouldRun = newShouldRunDecision;
@@ -578,12 +591,40 @@ public class SyncthingService extends Service {
         });
     }
 
+    public void registerOnRunConditionCheckResultChange(OnRunConditionCheckResultListener listener) {
+        listener.onRunConditionCheckResultChanged(mCurrentCheckResult.get());
+        mOnRunConditionCheckResultListeners.add(listener);
+    }
+
+    public void unregisterOnRunConditionCheckResultChange(OnRunConditionCheckResultListener listener) {
+        mOnRunConditionCheckResultListeners.remove(listener);
+    }
+
+    private void onRunConditionCheckResultChange(RunConditionCheckResult result) {
+        mHandler.post(() -> {
+            for (Iterator<OnRunConditionCheckResultListener> i = mOnRunConditionCheckResultListeners.iterator();
+                 i.hasNext(); ) {
+                OnRunConditionCheckResultListener listener = i.next();
+                if (listener != null) {
+                    listener.onRunConditionCheckResultChanged(result);
+                } else {
+                    i.remove();
+                }
+            }
+        });
+    }
+
+
     public URL getWebGuiUrl() {
         return mConfig.getWebGuiUrl();
     }
 
     public State getCurrentState() {
         return mCurrentState;
+    }
+
+    public RunConditionCheckResult getCurrentRunConditionCheckResult() {
+        return mCurrentCheckResult.get();
     }
 
     public NotificationHandler getNotificationHandler() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -653,6 +653,19 @@ Please report any problems you encounter via Github.</string>
     <!-- Button text on the "syncthing disabled" dialog, used as menu item to stop syncthing service if "always_run_in_background" is true -->
     <string name="exit">Exit</string>
 
+    <!-- Reasons for "syncthing disabled" dialog -->
+    <string name="syncthing_disabled_reason_heading">Reasons:</string>
+    <string name="syncthing_disabled_reason_on_battery">Device is running on battery</string>
+    <string name="syncthing_disabled_reason_on_charger">Device is running on charger</string>
+    <string name="syncthing_disabled_reason_powersaving">Device is in power-saving mode</string>
+    <string name="syncthing_disabled_reason_android_sync_disabled">Global Synchronization is disabled</string>
+    <string name="syncthing_disabled_reason_wifi_ssid_not_whitelisted">Current WiFi SSID is not whitelisted</string>
+    <string name="syncthing_disabled_reason_wifi_is_metered">Current WiFi is metered</string>
+    <string name="syncthing_disabled_reason_no_network_or_flightmode">No network connection or airplane mode enabled</string>
+    <string name="syncthing_disabled_reason_no_mobile_connection">Not connected to mobile data</string>
+    <string name="syncthing_disabled_reason_no_wifi_connection">Not connected to WiFi</string>
+    <string name="syncthing_disabled_reason_no_allowed_method">Not configured to sync on WiFi nor mobile data</string>
+
     <!-- Title of the notification shown while syncthing is running and enabled -->
     <string name="syncthing_active">Syncthing is running</string>
 


### PR DESCRIPTION
This implementation aims to change the actual run-condition check as little as possible, but returns a set of reasons instead of a single boolean. Since the original implementation returns early in several cases, this early returns are simulated but still attempt to collect all applying reasons.