### PR TITLE
Use go stable instead of 1.9 for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
   # Install Go using gimme tool
   - curl -sL -o ~/bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
   - chmod +x ~/bin/gimme
-  - eval "$(gimme 1.9)"
+  - eval "$(gimme stable)"
   # Hack to accept Android licenses
   - yes | sdkmanager "platforms;android-27"
 


### PR DESCRIPTION
Since https://github.com/syncthing/syncthing-android/pull/1265 there's no reason to use go 1.9 anymore. Even more the missing gomodules support in that breaks the build process.