### PR TITLE
Bumped version to 1.1.1-rc.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,8 +35,8 @@ android {
         applicationId "com.nutomic.syncthingandroid"
         minSdkVersion 16
         targetSdkVersion 26
-        versionCode 4161
-        versionName "0.10.19"
+        versionCode 4162
+        versionName "1.1.1-rc.1"
         testApplicationId 'com.nutomic.syncthingandroid.test'
         testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
         playAccountConfig = playAccountConfigs.defaultAccountConfig

--- a/app/src/main/play/en-GB/whatsnew
+++ b/app/src/main/play/en-GB/whatsnew
@@ -1,2 +1,1 @@
-* Update syncthing to v1.1.0
-* Fallback to http if https with TLS 1.2 is unavailable (#1255)
+* Update syncthing to v1.1.1-rc.1


### PR DESCRIPTION
This prepares the release of the current syncthing RC as 1.1.1-rc.1 (to beta track) as discussed in https://forum.syncthing.net/t/android-new-versioning-scheme/12929  
Should there be a note in whatsnew regarding the new versioning policy?