### PR TITLE
Disable badge for persistent notification (fixes #1305)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/service/NotificationHandler.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/NotificationHandler.java
@@ -57,6 +57,7 @@ public class NotificationHandler {
             mPersistentChannel.enableLights(false);
             mPersistentChannel.enableVibration(false);
             mPersistentChannel.setSound(null, null);
+            mPersistentChannel.setShowBadge(false); // Disables the dot next to the app icon
             mNotificationManager.createNotificationChannel(mPersistentChannel);
 
             mPersistentChannelWaiting = new NotificationChannel(


### PR DESCRIPTION
**Purpose:**

As mentioned in #1305, some users don't like the "dot" (badge) displayed when there is not really new info available.

**Changes:**

The current behavior is that the dot is always shown when syncthing has a notification open - usually the persistent `Syncthing is running` message used for the background service.

This PR changes this behavior and disables the dot/badge when only the `Syncthing is running` notification is displayed. This does not affect the operation of the notification or the service.

_Please note that this **only** affects the `Syncthing is running` notification._ The `Syncthing is disabled` message or other info notifications will still get a badge. This is intentional, because I think these notifications deserve attention from the user.

**Tests:**

I verified this briefly on Android Emulators running Android 8.1, 7.0 and 4.4. On API level >= 26 (Oreo) this works as intended, on lower Androids this has no effect because this feature does not exist.

**Compatibility note:**
`NotificationChannel.setShowBadge()` was added in API level 26. The buildscript currently targets/compiles this API level, therefore I concluded that usage of this method is unproblematic. The method call is guarded by a version comparison, to avoid calling this on anything lower than Oreo.