### PR TITLE
Don't open keyboard on save to Syncthing

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/ShareActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/ShareActivity.java
@@ -39,6 +39,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static android.view.WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN;
+
 /**
  * Shares incoming files to syncthing folders.
  * <p>
@@ -101,6 +103,8 @@ public class ShareActivity extends StateDialogActivity
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_share);
+
+        getWindow().setSoftInputMode(SOFT_INPUT_STATE_ALWAYS_HIDDEN);
 
         registerOnServiceConnectedListener(this);
 


### PR DESCRIPTION
Hi all,

the way I am using syncthing I am usually moving one file at a time. It gets really frustrating having to close the keyboard each time in order to reach the save button.
![Imgur](https://i.imgur.com/ym5vrbj.png?2)

Albeit when I happen to choose multiple files this issue seems "fixed"
![Imgur](https://i.imgur.com/unTyLhz.png)

The one liner addition though seems to fix the issue.

At the very least if you don't accept my pull req please consider having it addressed on some future release.