### PR TITLE
Bump gradle from 3.1.3 to 3.4.2 

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
@@ -125,7 +125,7 @@ public class SyncthingRunnable implements Runnable {
         // Potential fix for #498, keep the CPU running while native binary is running
         PowerManager pm = (PowerManager) mContext.getSystemService(Context.POWER_SERVICE);
         PowerManager.WakeLock wakeLock = useWakeLock()
-                ? pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, TAG)
+                ? pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK,  mContext.getString(R.string.app_name) + ":" + TAG)
                 : null;
         try {
             if (wakeLock != null)

--- a/app/src/main/res/layout/item_folder_list.xml
+++ b/app/src/main/res/layout/item_folder_list.xml
@@ -32,7 +32,6 @@
                 android:id="@+id/state"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_alignBottom="@id/id"
                 android:layout_alignParentEnd="true"
                 android:layout_alignParentRight="true"
                 android:textAppearance="?textAppearanceListItemSmall" />

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.4.2'
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.22.0'
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
This is pure monkey-patching on my part to hopefully fix https://build.syncthing.net/viewLog.html?buildId=44814&buildTypeId=SyncthingAndroid_Build&tab=buildLog:
```
[Step 1/1]   Errors found:
[09:02:54]
[Step 1/1]   
[09:02:54]
[Step 1/1]   /opt/tcagent/syncthing-3-work/19a8ed19ae4d1032/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java:128: Error: Tag name should use a unique prefix followed by a colon (found SyncthingRunnable). For instance myapp:mywakelocktag. This will help with debugging [InvalidWakeLockTag]
[09:02:54]
[Step 1/1]                   ? pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, TAG)
[09:02:54]
[Step 1/1]                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[09:02:54]
[Step 1/1]   /opt/tcagent/syncthing-3-work/19a8ed19ae4d1032/app/src/main/res/layout/item_folder_list.xml:35: Error: @id/id is not a sibling in the same RelativeLayout [NotSibling]
[09:02:54]
[Step 1/1]                   android:layout_alignBottom="@id/id"
[09:02:54]
[Step 1/1]                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[09:02:54]
[Step 1/1]   
```

 The wakelock tag unique id snippet is from https://github.com/Catfriend1/syncthing-android/commit/6ee9f26fb7485e064e94ceaed9e096e3e7035c20#diff-4f38101b94f632fe978cd535f1ff8f20R152
, thanks @Catfriend1

EDIT: Gradle is happy now -> yolo-merge

