### PR TITLE
Remove go mod download as part of build

### DIFF
--- a/syncthing/build-syncthing.py
+++ b/syncthing/build-syncthing.py
@@ -113,7 +113,6 @@ for target in BUILD_TARGETS:
         'CGO_ENABLED': '1',
     })
 
-    subprocess.check_call(['go', 'mod', 'download'], cwd=syncthing_dir)
     subprocess.check_call([
         'go', 'run', 'build.go', '-goos', 'android', '-goarch', target['goarch'], '-cc', os.path.join(standalone_ndk_dir, 'bin', target['cc'])
     ] + pkg_argument + ['-no-upgrade', 'build'], env=environ, cwd=syncthing_dir)


### PR DESCRIPTION
I don't see why we'd need to explicitly download modules.

This doesn't require a new deploy, so directly testable.

