### PR TITLE
FOREGROUND_SERVICE is required if targetSdkVersion is set to 28

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,8 @@
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
     <!-- ACCESS_COARSE_LOCATION is required to get WiFi's SSID on 8.1 -->
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <!-- FOREGROUND_SERVICE is required if targetSdkVersion is set to 28+ -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <application
         android:allowBackup="false"


### PR DESCRIPTION
Reference: https://developer.android.com/about/versions/pie/android-9.0-migration#tya and https://stackoverflow.com/a/52382711