### PR TITLE
Disable NAT option if a buggy 3.4 kernel is detected

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
@@ -138,4 +138,17 @@ public class Constants {
 
         return true;
     }
+
+    /**
+     * Detect kernels with a bug causing kernel oops when
+     * Syncthing v1.3.0+ attempts to enable the NAT feature.
+     * See: https://github.com/syncthing/syncthing-android/issues/1425
+     */
+    public static Boolean osHasKernel34() {
+        String kernelVersion = java.lang.System.getProperty("os.version");
+        if (kernelVersion == null) {
+            return false;
+        }
+        return kernelVersion.startsWith("3.4.");
+    }
 }

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
@@ -210,6 +210,14 @@ public class ConfigXml {
             }
         }
 
+        /**
+         * Disable Syncthing's NAT feature because it causes kernel oops on some buggy kernels.
+         */
+        if (Constants.osHasKernel34()) {
+            Log.v(TAG, "Disabling NAT option because a buggy kernel was detected. See https://github.com/syncthing/syncthing-android/issues/1425 .");
+            changed = setConfigElement(options, "natEnabled", Boolean.toString(false)) || changed;
+        }
+
         // Save changes if we made any.
         if (changed) {
             saveChanges();


### PR DESCRIPTION
Original code from: https://github.com/Catfriend1/syncthing-android/pull/513

Fix #1425