### PR TITLE
build x86_64 binary to accomodate google play

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,10 @@ android:
 # Install Android NDK (apparently there is no easier way to do this)
 # https://github.com/travis-ci/travis-ci/issues/5395
 before_script:
-  - curl -L https://dl.google.com/android/repository/android-ndk-r15c-linux-x86_64.zip -O
-  - unzip -q android-ndk-r15c-linux-x86_64.zip
-  - export ANDROID_NDK_HOME=`pwd`/android-ndk-r15c
+  - export NDK_VERSION=r20
+  - curl -L https://dl.google.com/android/repository/android-ndk-${NDK_VERSION}-linux-x86_64.zip -O
+  - unzip -q android-ndk-${NDK_VERSION}-linux-x86_64.zip
+  - export ANDROID_NDK_HOME=`pwd`/android-ndk-${NDK_VERSION}
 
 before_install:
   # Install Go using gimme tool

--- a/docker/prebuild.sh
+++ b/docker/prebuild.sh
@@ -2,7 +2,7 @@
 
 [ -z "$SYNCTHING_ANDROID_PREBUILT" ] && echo "Prebuild disabled" && exit 0
 
-for ARCH in arm x86 arm64; do
+for ARCH in arm x86 arm64 x86_64; do
   GOARCH=${ARCH}
   SDK=16
   case ${ARCH} in
@@ -16,6 +16,10 @@ for ARCH in arm x86 arm64; do
       x86)
         GOARCH=386
         GCC="i686-linux-android-clang"
+        ;;
+      x86_64)
+        SDK=21
+        GCC="x86_64-linux-android21-clang"
         ;;
       *)
         echo "Invalid architecture"

--- a/syncthing/build-syncthing.py
+++ b/syncthing/build-syncthing.py
@@ -32,6 +32,7 @@ BUILD_TARGETS = [
         'goarch': 'amd64',
         'jni_dir': 'x86_64',
         'clang': 'x86_64-linux-android21-clang',
+        'min_sdk': 21,
     }
 ]
 

--- a/syncthing/build-syncthing.py
+++ b/syncthing/build-syncthing.py
@@ -31,7 +31,7 @@ BUILD_TARGETS = [
         'arch': 'x86_64',
         'goarch': 'amd64',
         'jni_dir': 'x86_64',
-        'clang': 'x86_64-linux-android21-clang',
+        'cc': 'x86_64-linux-android21-clang',
         'min_sdk': 21,
     }
 ]

--- a/syncthing/build-syncthing.py
+++ b/syncthing/build-syncthing.py
@@ -26,6 +26,12 @@ BUILD_TARGETS = [
         'goarch': '386',
         'jni_dir': 'x86',
         'cc': 'i686-linux-android-clang',
+    },
+    {
+        'arch': 'x86_64',
+        'goarch': 'amd64',
+        'jni_dir': 'x86_64',
+        'clang': 'x86_64-linux-android21-clang',
     }
 ]
 


### PR DESCRIPTION
As @Catfriend1 [pointed out a while ago ](https://forum.syncthing.net/t/new-release-is-tagged-and-built-for-tomorrow/13114/15) (thanks!) and the play console is nagging whenever I do a release, we also need to provide the 64bit variant of x86 build. I just copied the section Catfriend1 pointed me to: https://github.com/Catfriend1/syncthing-android/blob/5778faeaf9941f06f435d4ffebae19d1051f0a46/syncthing/build-syncthing.py#L47