### PR TITLE
Add privacy policy for play store

### DIFF
--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -1,0 +1,4 @@
+# Privacy Policy
+
+The app syncthing-android does not collect any user information. It does run Syncthing, which does expose some networking information to work and may collect usage-data if you agree to it or run betas/release candidates. This documentation article has specific information on this: https://docs.syncthing.net/users/security.html  
+The app uses the camera solely to scan QR-codes to enter a device ID. Pictures are not stored in the process.


### PR DESCRIPTION
The play store rejects the update due to a missing privacy policy. Apparently needing the camera requires having one, and we do need the camera since https://github.com/syncthing/syncthing-android/pull/1556