### PR TITLE
Add "all files" management permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,8 @@
     <uses-feature android:name="android.hardware.location.gps" android:required="false" />
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <!-- ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION is required to access files from other apps on 11 "R" -->
+    <uses-permission android:name="android.permission.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />


### PR DESCRIPTION
Android 11 (R) requires the new "ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION" permission, added in this version, to view the files of other applications.