### PR TITLE
Target android sdk 29

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,8 +25,8 @@ dependencies {
 
 android {
     // Changes to these values need to be reflected in `.travis.yml`
-    compileSdkVersion 28
-    buildToolsVersion '28.0.3'
+    compileSdkVersion 29
+    buildToolsVersion '29.0.3'
 
     buildTypes.debug.applicationIdSuffix ".debug"
     dataBinding.enabled = true
@@ -39,7 +39,7 @@ android {
     defaultConfig {
         applicationId "com.nutomic.syncthingandroid"
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 4253
         versionName "1.11.1"
         testApplicationId 'com.nutomic.syncthingandroid.test'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,8 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <!-- ACCESS_FINE_LOCATION is required to get WiFi's SSID on 10 "Q" -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <!-- ACCESS_BACKGROUND_LOCATION is required to get WiFi's SSID on 10 "Q" -->
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <!-- CAMERA is required for the QR Code Scanner -->
     <uses-permission android:name="android.permission.CAMERA" />
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,6 +34,7 @@
         android:description="@string/app_description"
         android:supportsRtl="true"
         android:installLocation="internalOnly"
+        android:requestLegacyExternalStorage="true"
         android:name=".SyncthingApp">
         <activity
                 android:name=".activities.FirstStartActivity"

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FirstStartActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FirstStartActivity.java
@@ -39,8 +39,7 @@ import javax.inject.Inject;
 public class FirstStartActivity extends Activity {
 
     private static String TAG = "FirstStartActivity";
-    private static final int REQUEST_COARSE_LOCATION = 141;
-    private static final int REQUEST_WRITE_STORAGE = 142;
+
     private static final int SLIDE_POS_LOCATION_PERMISSION = 1;
 
     private ViewPager mViewPager;
@@ -300,8 +299,8 @@ public class FirstStartActivity extends Activity {
      */
     private void requestLocationPermission() {
         ActivityCompat.requestPermissions(this,
-                new String[]{Manifest.permission.ACCESS_COARSE_LOCATION},
-                REQUEST_COARSE_LOCATION);
+                Constants.getLocationPermissions(),
+                Constants.PermissionRequestType.LOCATION.ordinal());
     }
 
     private boolean haveStoragePermission() {
@@ -313,23 +312,32 @@ public class FirstStartActivity extends Activity {
     private void requestStoragePermission() {
         ActivityCompat.requestPermissions(this,
                 new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
-                REQUEST_WRITE_STORAGE);
+                Constants.PermissionRequestType.STORAGE.ordinal());
     }
 
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
                                            @NonNull int[] grantResults) {
-        switch (requestCode) {
-            case REQUEST_COARSE_LOCATION:
-                if (grantResults.length == 0 ||
-                        grantResults[0] != PackageManager.PERMISSION_GRANTED) {
-                    Log.i(TAG, "User denied ACCESS_COARSE_LOCATION permission.");
-                } else {
+        switch (Constants.PermissionRequestType.values()[requestCode]) {
+            case LOCATION:
+                boolean granted = grantResults.length != 0;
+                if (!granted) {
+                    Log.i(TAG, "No location permission in request-result");
+                    break;
+                }
+                for (int i = 0; i < grantResults.length; i++) {
+                    if (grantResults[i] == PackageManager.PERMISSION_GRANTED) {
+                        Log.i(TAG, "User granted permission: " + permissions[i]);
+                    } else {
+                        granted = false;
+                        Log.i(TAG, "User denied permission: " + permissions[i]);
+                    }
+                }
+                if (granted) {
                     Toast.makeText(this, R.string.permission_granted, Toast.LENGTH_SHORT).show();
-                    Log.i(TAG, "User granted ACCESS_COARSE_LOCATION permission.");
                 }
                 break;
-            case REQUEST_WRITE_STORAGE:
+            case STORAGE:
                 if (grantResults.length == 0 ||
                         grantResults[0] != PackageManager.PERMISSION_GRANTED) {
                     Log.i(TAG, "User denied WRITE_EXTERNAL_STORAGE permission.");

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -66,20 +66,22 @@ public class SettingsActivity extends SyncthingActivity {
 
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-        // On Android 8.1, ACCESS_COARSE_LOCATION is required, see issue #999
-        if (requestCode == Constants.PERM_REQ_ACCESS_COARSE_LOCATION) {
-            for (int i = 0; i < permissions.length; i++) {
-                if (Manifest.permission.ACCESS_COARSE_LOCATION.equals(permissions[i])) {
-                    if (grantResults[i] == PackageManager.PERMISSION_GRANTED) {
-                        this.startService(new Intent(this, SyncthingService.class)
-                                .setAction(SyncthingService.ACTION_REFRESH_NETWORK_INFO));
-                    } else {
-                        Util.getAlertDialogBuilder(this)
-                                .setTitle(R.string.sync_only_wifi_ssids_location_permission_rejected_dialog_title)
-                                .setMessage(R.string.sync_only_wifi_ssids_location_permission_rejected_dialog_content)
-                                .setPositiveButton(android.R.string.ok, null).show();
-                    }
+        if (requestCode == Constants.PermissionRequestType.LOCATION.ordinal()) {
+            boolean granted = grantResults.length > 0;
+            for (int i = 0; i < grantResults.length; i++) {
+                if (grantResults[i] != PackageManager.PERMISSION_GRANTED) {
+                    granted = false;
+                    break;
                 }
+            }
+            if (granted) {
+                this.startService(new Intent(this, SyncthingService.class)
+                        .setAction(SyncthingService.ACTION_REFRESH_NETWORK_INFO));
+            } else {
+                Util.getAlertDialogBuilder(this)
+                    .setTitle(R.string.sync_only_wifi_ssids_location_permission_rejected_dialog_title)
+                    .setMessage(R.string.sync_only_wifi_ssids_location_permission_rejected_dialog_content)
+                    .setPositiveButton(android.R.string.ok, null).show();
             }
         }
     }

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
@@ -1,5 +1,6 @@
 package com.nutomic.syncthingandroid.service;
 
+import android.Manifest;
 import android.content.Context;
 import android.os.Build;
 import android.os.Environment;
@@ -48,10 +49,29 @@ public class Constants {
     public static final String FOLDER_TYPE_RECEIVE_ONLY         = "receiveonly";
 
     /**
-     * On Android 8.1, ACCESS_COARSE_LOCATION is required to access WiFi SSID.
-     * This is the request code used when requesting the permission.
+     * These are the request codes used when requesting the permissions.
      */
-    public static final int PERM_REQ_ACCESS_COARSE_LOCATION = 999; // for issue #999
+    public enum PermissionRequestType {
+        LOCATION, STORAGE
+    }
+
+    public static String[] getLocationPermissions() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) { // before android 9
+            return new String[]{
+                Manifest.permission.ACCESS_COARSE_LOCATION,
+            };
+        }
+        if (Build.VERSION.SDK_INT == Build.VERSION_CODES.P) { // android 9
+            return new String[]{
+                Manifest.permission.ACCESS_FINE_LOCATION,
+            };
+        }
+        return new String[]{  // after android 9
+            Manifest.permission.ACCESS_FINE_LOCATION,
+            Manifest.permission.ACCESS_BACKGROUND_LOCATION,
+        };
+    }
+
 
     /**
      * Interval in ms at which the GUI is updated (eg {@link com.nutomic.syncthingandroid.fragments.DrawerFragment}).

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
@@ -55,6 +55,10 @@ public class Constants {
         LOCATION, STORAGE
     }
 
+    /**
+     * Returns the location permissions required to access wifi SSIDs depending
+     * on the respective Android version.
+     */
     public static String[] getLocationPermissions() {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) { // before android 9
             return new String[]{

--- a/app/src/main/java/com/nutomic/syncthingandroid/views/WifiSsidPreference.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/views/WifiSsidPreference.java
@@ -69,21 +69,30 @@ public class WifiSsidPreference extends MultiSelectListPreference {
         selected = new HashSet<>(selected);
         List<String> all = new ArrayList<>(selected);
 
+        boolean connected = false;
         WifiManager wifiManager = (WifiManager) context.getApplicationContext().getSystemService(Context.WIFI_SERVICE);
         if (wifiManager != null) {
             WifiInfo info = wifiManager.getConnectionInfo();
             if (info != null) {
                 String ssid = info.getSSID();
-                if (ssid != "" && !selected.contains(ssid)) {
+                // api lvl 30 will have WifiManager.UNKNOWN_SSID
+                if (ssid != "" && !ssid.contains("unknown ssid") && !selected.contains(ssid)) {
                     all.add(ssid);
+                    connected = true;
                 }
             }
         }
-                
-        setEntries(stripQuotes(all)); // display without surrounding quotes
-        setEntryValues(all.toArray(new CharSequence[all.size()])); // the value of the entry is the SSID "as is"
-        setValues(selected); // the currently selected values (without meanwhile deleted networks)
-        super.showDialog(state);
+
+        if (!connected) {
+            Toast.makeText(context, R.string.sync_only_wifi_ssids_connect_to_wifi, Toast.LENGTH_LONG).show();
+        }
+
+        if (all.size() > 0 ) {
+            setEntries(stripQuotes(all)); // display without surrounding quotes
+            setEntryValues(all.toArray(new CharSequence[all.size()])); // the value of the entry is the SSID "as is"
+            setValues(selected); // the currently selected values (without meanwhile deleted networks)
+            super.showDialog(state);
+        }
 
         String[] perms = Constants.getLocationPermissions();
         boolean granted = true;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -324,6 +324,7 @@ Please report any problems you encounter via Github.</string>
     <string name="run_on_all_wifi_networks">Run on all Wi-Fi networks.</string>
 
     <string name="sync_only_wifi_ssids_wifi_turn_on_wifi">Please turn on Wi-Fi to select networks.</string>
+    <string name="sync_only_wifi_ssids_connect_to_wifi">Please connect to a Wi-Fi to add it to the list.</string>
 
     <string name="sync_only_wifi_ssids_need_to_grant_location_permission">You need to grant LOCATION permission to use this feature.</string>
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8
 
-ENV GO_VERSION 1.15.2
+ENV GO_VERSION 1.15.5
 ENV ANDROID_SDK_VERSION 3859397
 
 WORKDIR /opt
@@ -23,7 +23,7 @@ ENV ANDROID_HOME /opt/android-sdk
 RUN yes | ${ANDROID_HOME}/tools/bin/sdkmanager --licenses
 
 # Install other android packages, including NDK
-RUN ${ANDROID_HOME}/tools/bin/sdkmanager tools platform-tools "build-tools;27.0.2" "platforms;android-27" "extras;android;m2repository" ndk-bundle
+RUN ${ANDROID_HOME}/tools/bin/sdkmanager tools platform-tools "build-tools;29.0.3" "platforms;android-29" "extras;android;m2repository" ndk-bundle
 
 # Accept licenses of newly installed packages
 RUN yes | ${ANDROID_HOME}/tools/bin/sdkmanager --licenses


### PR DESCRIPTION
This PR bumps our target sdk level to 29 (android 10), requesting legacy storage. This is a requirement for publishing google play updates (caveat at the end). The behaviour *shouldn't* change, but what should and shouldn't happen on android is a mystery, so I'll add a call for testing/feedback on the forum once this is in a release candidate.

@Catfriend1 A sanity check if I missed something obvious would be appreciated. I did follow the Android 11 troubles you had, but I believe those problems should not come up as we still target android 10/sdk 29. 

Google play caveat:  
<strike>Google is blocking us at the moment anyway, as suddenly our coarse access location permission for restricting sync by wifi name seems to be a problem - I wrote to the support, I am expecting a resolution in 6-8 weeks. I intend to keep releasing as usual, users annoyed by not getting those release should switch to F-Droid (users should anyway switch to F-Droid ;) ). </strike>  
Google support has responded, details in https://forum.syncthing.net/t/how-to-react-to-google-play-restrictions/15872/26

For reference:  
 - WiFi permissions: https://developer.android.com/guide/topics/connectivity/wifi-scan
 - Deprecated method: https://developer.android.com/reference/android/net/wifi/WifiManager.html#getConfiguredNetworks()