### PR TITLE
Containers and build process improvements/fixes

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,16 +20,19 @@ RUN mkdir -p /opt/android-sdk && cd /opt/android-sdk && \
 ENV ANDROID_HOME /opt/android-sdk
 
 # Accept the SDK license, as we can't install packages otherwise
-RUN yes | ${ANDROID_HOME}/tools/bin/sdkmanager --licenses
+RUN yes | ${ANDROID_HOME}/tools/bin/sdkmanager --licenses > /dev/null
+
+# NDK version (r22 fails to build)
+ENV NDK_VERSION 21.4.7075529
 
 # Install other android packages, including NDK
-RUN ${ANDROID_HOME}/tools/bin/sdkmanager tools platform-tools "build-tools;29.0.3" "platforms;android-29" "extras;android;m2repository" ndk-bundle
+RUN ${ANDROID_HOME}/tools/bin/sdkmanager tools platform-tools "build-tools;29.0.3" "platforms;android-29" "extras;android;m2repository" "ndk;${NDK_VERSION}"
 
 # Accept licenses of newly installed packages
 RUN yes | ${ANDROID_HOME}/tools/bin/sdkmanager --licenses
 
 # Setup the NDK path
-ENV ANDROID_NDK_HOME ${ANDROID_HOME}/ndk-bundle
+ENV ANDROID_NDK_HOME ${ANDROID_HOME}/ndk/${NDK_VERSION}
 
 # Enable prebuild mode
 ENV SYNCTHING_ANDROID_PREBUILT 1

--- a/docker/prebuild.sh
+++ b/docker/prebuild.sh
@@ -2,45 +2,8 @@
 
 [ -z "$SYNCTHING_ANDROID_PREBUILT" ] && echo "Prebuild disabled" && exit 0
 
-for ARCH in arm x86 arm64 x86_64; do
-  GOARCH=${ARCH}
-  SDK=16
-  # The values here must correspond with those in ../syncthing/build-syncthing.py
-  case ${ARCH} in
-      arm)
-        GCC="arm-linux-androideabi-clang"
-        ;;
-      arm64)
-        SDK=21
-        GCC="aarch64-linux-android-clang"
-        ;;
-      x86)
-        GOARCH=386
-        GCC="i686-linux-android-clang"
-        ;;
-      x86_64)
-        SDK=21
-        GOARCH=amd64
-        GCC="x86_64-linux-android21-clang"
-        ;;
-      *)
-        echo "Invalid architecture"
-        exit 1
-  esac
-
-  STANDALONE_NDK_DIR="${ANDROID_NDK_HOME}/standalone-ndk/android-${SDK}-${GOARCH}"
-  echo "Building standalone NDK - ${STANDALONE_NDK_DIR}"
-  ${ANDROID_NDK_HOME}/build/tools/make-standalone-toolchain.sh \
-    --platform=android-${SDK} --arch=${ARCH} \
-    --install-dir=${STANDALONE_NDK_DIR}
-
-   echo "Pre-building Go standard library for $GOARCH"
-   CGO_ENABLED=1 CC="${STANDALONE_NDK_DIR}/bin/${GCC}" \
-      GOOS=android GOARCH=$GOARCH go install -v std
-done
-
 echo "Prepopulating gradle and go build/pkg cache"
-git clone https://github.com/syncthing/syncthing-android
+git clone --recurse-submodules https://github.com/syncthing/syncthing-android
 cd syncthing-android
 ./gradlew --no-daemon lint buildNative
 cd ..


### PR DESCRIPTION
 - Use ndk 21 due to Go bug: https://github.com/golang/go/issues/42655

 - Use pre-built clang binaries instead of building ourselves  
The script building the standalone-ndk printed these messages saying you don't actually need to build it but use these pre-built ones already part of the ndk as downloaded. I assume that was just not in place at the time this step was created - or is there a catch? @AudriusButkevicius 

 - Build syncthing when creating container to prepopulate modules