### PR TITLE
Follow gplay directions regarding privacy policy and location disclosure

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,6 +27,7 @@ android {
     // Changes to these values need to be reflected in `.travis.yml`
     compileSdkVersion 29
     buildToolsVersion '29.0.3'
+    ndkVersion = '21.4.7075529'
 
     buildTypes.debug.applicationIdSuffix ".debug"
     dataBinding.enabled = true

--- a/app/src/main/play/listings/en-GB/full-description.txt
+++ b/app/src/main/play/listings/en-GB/full-description.txt
@@ -7,3 +7,5 @@ Source code: https://github.com/syncthing/syncthing-android
 Forum: https://forum.syncthing.net/
 
 Issues: https://github.com/syncthing/syncthing-android/issues
+
+Privacy-policy: https://github.com/syncthing/syncthing-android/blob/main/privacy-policy.md

--- a/app/src/main/res/layout/activity_firststart_slide1.xml
+++ b/app/src/main/res/layout/activity_firststart_slide1.xml
@@ -36,17 +36,24 @@
             android:textSize="@dimen/slide_title"
             android:textStyle="bold" />
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="20dp"
-            android:paddingLeft="@dimen/desc_padding"
-            android:paddingRight="@dimen/desc_padding"
-            android:text="@string/welcome_text"
-            android:textAlignment="center"
-            android:layout_gravity="center_horizontal"
-            android:textColor="@android:color/white"
-            android:textSize="@dimen/slide_desc" />
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/desc_marginTop"
+                android:paddingLeft="@dimen/desc_padding"
+                android:paddingRight="@dimen/desc_padding"
+                android:paddingBottom="@dimen/desc_paddingBottom"
+                android:text="@string/welcome_text"
+                android:textAlignment="center"
+                android:layout_gravity="center_horizontal"
+                android:textColor="@android:color/white"
+                android:textSize="@dimen/slide_desc" />
+
+        </ScrollView>
 
     </LinearLayout>
 </RelativeLayout>

--- a/app/src/main/res/layout/activity_firststart_slide2.xml
+++ b/app/src/main/res/layout/activity_firststart_slide2.xml
@@ -51,17 +51,24 @@
             android:textSize="@dimen/slide_title"
             android:textStyle="bold" />
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="20dp"
-            android:paddingLeft="@dimen/desc_padding"
-            android:paddingRight="@dimen/desc_padding"
-            android:text="@string/storage_permission_desc"
-            android:textAlignment="center"
-            android:layout_gravity="center_horizontal"
-            android:textColor="@android:color/white"
-            android:textSize="@dimen/slide_desc" />
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/desc_marginTop"
+                android:paddingLeft="@dimen/desc_padding"
+                android:paddingRight="@dimen/desc_padding"
+                android:paddingBottom="@dimen/desc_paddingBottom"
+                android:text="@string/storage_permission_desc"
+                android:textAlignment="center"
+                android:layout_gravity="center_horizontal"
+                android:textColor="@android:color/white"
+                android:textSize="@dimen/slide_desc" />
+
+        </ScrollView>
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/activity_firststart_slide3.xml
+++ b/app/src/main/res/layout/activity_firststart_slide3.xml
@@ -49,19 +49,28 @@
             android:text="@string/location_permission_title"
             android:textColor="@android:color/white"
             android:textSize="@dimen/slide_title"
-            android:textStyle="bold" />
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="20dp"
-            android:paddingLeft="@dimen/desc_padding"
-            android:paddingRight="@dimen/desc_padding"
-            android:text="@string/location_permission_desc"
+            android:textStyle="bold"
             android:textAlignment="center"
-            android:layout_gravity="center_horizontal"
-            android:textColor="@android:color/white"
-            android:textSize="@dimen/slide_desc" />
+            />
+
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginTop="@dimen/desc_marginTop"
+                android:paddingLeft="@dimen/desc_padding"
+                android:paddingRight="@dimen/desc_padding"
+                android:paddingBottom="@dimen/desc_paddingBottom"
+                android:text="@string/location_permission_desc"
+                android:textAlignment="center"
+                android:textColor="@android:color/white"
+                android:textSize="@dimen/slide_desc" />
+
+        </ScrollView>
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/activity_firststart_slide3.xml
+++ b/app/src/main/res/layout/activity_firststart_slide3.xml
@@ -46,6 +46,7 @@
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
             android:text="@string/location_permission_title"
             android:textColor="@android:color/white"
             android:textSize="@dimen/slide_title"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -10,5 +10,7 @@
     <dimen name="slide_title">30sp</dimen>
     <dimen name="slide_desc">16sp</dimen>
     <dimen name="desc_padding">40dp</dimen>
+    <dimen name="desc_marginTop">20dp</dimen>
+    <dimen name="desc_paddingBottom">80dp</dimen>
     <dimen name="button_height">44dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,8 +23,8 @@ Please report any problems you encounter via Github.</string>
     <string name="storage_permission_desc">Syncthing needs to access your storage to do file synchronization.</string>
 
     <!-- Slide 3 -->
-    <string name="location_permission_title">Location Permission</string>
-    <string name="location_permission_desc">Syncthing can be configured to run on selected Wi-Fi networks. Android requires applications to have location permissions to be able look up active Wi-Fi network name, as you can sometimes infer users location from the name of the network they are connected to. If you want to use this feature, press the button above to give the required location permissions to Syncthing. Otherwise you can skip this step.</string>
+    <string name="location_permission_title">Location Permission (background)</string>
+    <string name="location_permission_desc">Syncthing can be configured to synchronize on selected Wi-Fi networks only. To do that it needs to look up the SSID of the currently connected Wi-Fi, also when the app is closed. Therefore it requires permission to access the location in the background. This information is not used to look up your location. And the only stored information is the Wi-Fi you manually choose to add to the list - no other user data is stored.\n\n If you want to use this feature, press the button above to grant the required permissions to Syncthing. Otherwise you can skip this step.</string>
 
     <!-- Generic texts used everywhere -->
     <string name="back">Back</string>
@@ -553,6 +553,10 @@ Please report any problems you encounter via Github.</string>
     <string name="donate_summary">Help us pay for domains and hosting fees</string>
 
     <string name="donate_url" translatable="false">https://syncthing.net/donations/</string>
+
+    <!-- Menu item linking privacy policy -->
+    <string name="privacy_title">Privacy Policy</string>
+    <string name="privacy_summary">Open the Syncthing-Android privacy policy</string>
 
     <!-- Title of the preference showing upstream version name -->
     <string name="syncthing_version_title">Syncthing Version</string>

--- a/app/src/main/res/xml/app_settings.xml
+++ b/app/src/main/res/xml/app_settings.xml
@@ -304,6 +304,14 @@
         </Preference>
 
         <Preference
+            android:title="@string/privacy_title"
+            android:summary="@string/privacy_summary">
+            <intent
+                android:action="android.intent.action.VIEW"
+                android:data="https://github.com/syncthing/syncthing-android/blob/main/privacy-policy.md" />
+        </Preference>
+
+        <Preference
             android:key="syncthing_version"
             android:title="@string/syncthing_version_title" />
 

--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -1,6 +1,6 @@
 # Privacy Policy
 
-The app syncthing-android does not collect any user information. It does run Syncthing, which does expose some networking information to work and may collect usage-data if you agree to it or run betas/release candidates. This documentation article has specific information on this: https://docs.syncthing.net/users/security.html  
+The app syncthing-android does not collect any user information. It does run Syncthing, which does expose some networking information to work and may collect usage-data only if you agree to it or run betas/release candidates. This documentation article has specific information on this: https://docs.syncthing.net/users/security.html  
 
 The app requires the permission to access the location in the background, but it never does look up your location. The location permission is required to look up wifi SSIDs, which is used to enable/disable syncing on user configurable wifis.
 


### PR DESCRIPTION
Implements the changes suggested in the email received from google regarding their rejection of our app (currently we publish with an "exception" valid until end of March). I did everything they asked for and tried to use the exact phrases they quoted/suggested in the email :) 
 - Disclosure now talks about the "background" aspect.
 - Privacy policy is linked in app (about view) and in the store listing.

I intend to immediately publish a new RC (1.14.0-rc1.1) when this is merged and signify that we are now compliant, to trigger a review. If that fails, there's still some time to publish with the exception and try to fix whatever the complaints are again. Fingers crossed :)

I also wrapped the welcome screen texts into scroll views, because even before this change the text exceeded the display on my small (5''?) display.