### PR TITLE
Change capitalization from Github to GitHub in Welcome wizard

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,7 +16,7 @@
     <string name="introduction">Introduction</string>
     <string name="welcome_text">Syncthing is an open-source file synchronization application.\n\
 To share data with other devices, you need to add their unique device IDs to the device list. Afterwards you can select which folders to share with which devices.\n\
-Please report any problems you encounter via Github.</string>
+Please report any problems you encounter via GitHub.</string>
 
     <!-- Slide 2 -->
     <string name="storage_permission_title">Storage Permission</string>


### PR DESCRIPTION
In GitHub, both Git and Hub are capitalized. Let me know if you want me to fix up locales, too!