### PR TITLE
Improve privacy policy

### DIFF
--- a/app/src/main/play/listings/en-GB/full-description.txt
+++ b/app/src/main/play/listings/en-GB/full-description.txt
@@ -8,4 +8,4 @@ Forum: https://forum.syncthing.net/
 
 Issues: https://github.com/syncthing/syncthing-android/issues
 
-Privacy-policy: https://github.com/syncthing/syncthing-android/blob/main/privacy-policy.md
+Privacy-policy: https://syncthing.net/android-privacy-policy

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -556,7 +556,8 @@ Please report any problems you encounter via Github.</string>
 
     <!-- Menu item linking privacy policy -->
     <string name="privacy_title">Privacy Policy</string>
-    <string name="privacy_summary">Open the Syncthing-Android privacy policy</string>
+    <string name="privacy_summary">Open syncthing-android\'s privacy policy, which covers usage (if any) of personal data, e.g. location.</string>
+    <string name="privacy_policy_url" translatable="false">https://syncthing.net/android-privacy-policy</string>
 
     <!-- Title of the preference showing upstream version name -->
     <string name="syncthing_version_title">Syncthing Version</string>

--- a/app/src/main/res/xml/app_settings.xml
+++ b/app/src/main/res/xml/app_settings.xml
@@ -308,7 +308,7 @@
             android:summary="@string/privacy_summary">
             <intent
                 android:action="android.intent.action.VIEW"
-                android:data="https://github.com/syncthing/syncthing-android/blob/main/privacy-policy.md" />
+                android:data="@string/privacy_policy_url" />
         </Preference>
 
         <Preference

--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -1,7 +1,0 @@
-# Privacy Policy
-
-The app syncthing-android does not collect any user information. It does run Syncthing, which does expose some networking information to work and may collect usage-data only if you agree to it or run betas/release candidates. This documentation article has specific information on this: https://docs.syncthing.net/users/security.html  
-
-The app requires the permission to access the location in the background, but it never does look up your location. The location permission is required to look up wifi SSIDs, which is used to enable/disable syncing on user configurable wifis.
-
-The app uses the camera solely to scan QR-codes to enter a device ID. Pictures are not stored in the process.


### PR DESCRIPTION
I got feedback from google play support again, and now only our privacy policy isn't compliant any more (the prominent location disclosure now is - yeii xD ).

The (improved) privacy policy now lives at https://syncthing.net/android-privacy-policy  
https://github.com/syncthing/website/pull/18

I am not entirely sure what exactly was lacking before - here's the feedback:

> **Invalid privacy policy**
> 
> Based on our review, your privacy policy doesn't comply with our policy
> requirements. Please [add or update your privacy
> policy](https://support.google.com/googleplay/android-developer/answer/113469#privacy),
> and make sure it is available on an active URL (no PDFs), is
> non-editable, applies to your app, and **specifically covers user
> privacy including your app's usage of location data.** 
> 
> **Please make sure** privacy policy is *clearly labeled as a privacy
> policy in the context of the content* and specifies handling
> of location data.
> 
> Please note that the [Personal and Sensitive
> Information](https://support.google.com/googleplay/android-developer/answer/9888076#personal-sensitive) policy
> requires that: "The privacy policy must, together with any in-app
> disclosures, comprehensively disclose how your app accesses, collects,
> uses, and shares user data. Your privacy policy must disclose the types
> of personal and sensitive data your app accesses, collects, uses, and
> shares and the types of parties with which any personal or sensitive
> user data is shared."\

The part about labelling is emphasized, so I expanded the privacy policy description. I also made the privacy policy more explicit in terms of location data, as in specifically used the term "location data".  
Please share any other ideas/insights into what might be improved.

After merging I expect another round of the same game: Release, get an auto-rejection the day after and then ask support for an evaluation - lets see how that goes this time.