### PR TITLE
Add folder-device with enc-password (fixes #1673)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/model/Folder.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/model/Folder.java
@@ -20,7 +20,7 @@ public class Folder {
     public String type = Constants.FOLDER_TYPE_SEND_RECEIVE;
     public boolean fsWatcherEnabled = true;
     public int fsWatcherDelayS = 10;
-    private List<Device> devices = new ArrayList<>();
+    private List<Folder.Device> devices = new ArrayList<>();
     public int rescanIntervalS;
     public final boolean ignorePerms = true;
     public boolean autoNormalize = true;
@@ -79,5 +79,11 @@ public class Folder {
     @Override
     public String toString() {
         return !TextUtils.isEmpty(label) ? label : id;
+    }
+
+    public class Device {
+        public String deviceID;
+        public String introducedBy;
+        public String encryptionPassword;
     }
 }


### PR DESCRIPTION
I started looking into using the new "modular" config api (just patching the parts the wrapper cares about), however that required quite a lot of changes all over the place so I didn't get anywhere in the short amount of time I had. This hopefully fixes the issues people are seeing with encryption passwords and potentially other things, as the previous code wrongly used "normal devices" instead of "folder-devices".