### PR TITLE
Simplify welcome wizard layouts (fixes #1626, fixes #1723)

### DIFF
--- a/app/src/main/res/layout/activity_firststart_slide1.xml
+++ b/app/src/main/res/layout/activity_firststart_slide1.xml
@@ -3,12 +3,14 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:paddingBottom="@dimen/dots_full_height"
+    android:background="@color/bg_screen1"
     android:fillViewport="true">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/bg_screen1"
+
         android:gravity="center"
         android:orientation="vertical">
 

--- a/app/src/main/res/layout/activity_firststart_slide1.xml
+++ b/app/src/main/res/layout/activity_firststart_slide1.xml
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/bg_screen1">
+    android:fillViewport="true">
 
     <LinearLayout
-        android:background="@color/bg_screen1"
-        android:gravity="center_horizontal"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
+        android:background="@color/bg_screen1"
+        android:gravity="center"
         android:orientation="vertical">
 
         <TextView
             android:id="@+id/title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/welcome_title"
+            android:layout_margin="30dp"
             android:gravity="center"
+            android:text="@string/welcome_title"
             android:textColor="@android:color/white"
-            android:textSize="30sp"
-            android:layout_margin="30dp" />
+            android:textSize="30sp" />
 
         <ImageView
             android:layout_width="@dimen/img_width_height"
@@ -36,24 +36,19 @@
             android:textSize="@dimen/slide_title"
             android:textStyle="bold" />
 
-        <ScrollView
-            android:layout_width="match_parent"
-            android:layout_height="match_parent">
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/desc_marginTop"
-                android:paddingLeft="@dimen/desc_padding"
-                android:paddingRight="@dimen/desc_padding"
-                android:paddingBottom="@dimen/desc_paddingBottom"
-                android:text="@string/welcome_text"
-                android:textAlignment="center"
-                android:layout_gravity="center_horizontal"
-                android:textColor="@android:color/white"
-                android:textSize="@dimen/slide_desc" />
-
-        </ScrollView>
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="@dimen/desc_marginTop"
+            android:paddingLeft="@dimen/desc_padding"
+            android:paddingRight="@dimen/desc_padding"
+            android:paddingBottom="@dimen/desc_paddingBottom"
+            android:text="@string/welcome_text"
+            android:textAlignment="center"
+            android:textColor="@android:color/white"
+            android:textSize="@dimen/slide_desc" />
 
     </LinearLayout>
-</RelativeLayout>
+
+</ScrollView>

--- a/app/src/main/res/layout/activity_firststart_slide1.xml
+++ b/app/src/main/res/layout/activity_firststart_slide1.xml
@@ -1,16 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:paddingBottom="@dimen/dots_full_height"
     android:background="@color/bg_screen1"
-    android:fillViewport="true">
+    android:fillViewport="true"
+    android:paddingBottom="@dimen/dots_full_height">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-
         android:gravity="center"
         android:orientation="vertical">
 

--- a/app/src/main/res/layout/activity_firststart_slide2.xml
+++ b/app/src/main/res/layout/activity_firststart_slide2.xml
@@ -1,26 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/bg_screen2">
+    android:background="@color/bg_screen2"
+    android:fillViewport="true">
 
     <LinearLayout
-        android:background="@color/bg_screen2"
-        android:gravity="center_horizontal"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
+        android:gravity="center"
         android:orientation="vertical">
 
         <TextView
             android:id="@+id/title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/welcome_title"
+            android:layout_margin="30dp"
             android:gravity="center"
+            android:text="@string/welcome_title"
             android:textColor="@android:color/white"
-            android:textSize="30sp"
-            android:layout_margin="30dp" />
+            android:textSize="30sp" />
 
         <ImageView
             android:layout_width="@dimen/img_width_height"
@@ -33,14 +32,14 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"
-            android:paddingEnd="40dp"
-            android:paddingLeft="40dp"
-            android:paddingRight="40dp"
-            android:paddingStart="40dp"
-            android:text="@string/grant_permission"
             android:contentDescription="@string/grant_permission"
-            android:drawableLeft="@android:drawable/ic_menu_save"
             android:drawableStart="@android:drawable/ic_menu_save"
+            android:drawableLeft="@android:drawable/ic_menu_save"
+            android:paddingStart="40dp"
+            android:paddingLeft="40dp"
+            android:paddingEnd="40dp"
+            android:paddingRight="40dp"
+            android:text="@string/grant_permission"
             android:textSize="12sp" />
 
         <TextView
@@ -51,26 +50,19 @@
             android:textSize="@dimen/slide_title"
             android:textStyle="bold" />
 
-        <ScrollView
-            android:layout_width="match_parent"
-            android:layout_height="match_parent">
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/desc_marginTop"
-                android:paddingLeft="@dimen/desc_padding"
-                android:paddingRight="@dimen/desc_padding"
-                android:paddingBottom="@dimen/desc_paddingBottom"
-                android:text="@string/storage_permission_desc"
-                android:textAlignment="center"
-                android:layout_gravity="center_horizontal"
-                android:textColor="@android:color/white"
-                android:textSize="@dimen/slide_desc" />
-
-        </ScrollView>
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="@dimen/desc_marginTop"
+            android:paddingLeft="@dimen/desc_padding"
+            android:paddingRight="@dimen/desc_padding"
+            android:paddingBottom="@dimen/desc_paddingBottom"
+            android:text="@string/storage_permission_desc"
+            android:textAlignment="center"
+            android:textColor="@android:color/white"
+            android:textSize="@dimen/slide_desc" />
 
     </LinearLayout>
 
-
-</RelativeLayout>
+</ScrollView>

--- a/app/src/main/res/layout/activity_firststart_slide2.xml
+++ b/app/src/main/res/layout/activity_firststart_slide2.xml
@@ -3,8 +3,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/bg_screen2"
-    android:paddingBottom="@dimen/dots_full_height"
-    android:fillViewport="true">
+    android:fillViewport="true"
+    android:paddingBottom="@dimen/dots_full_height">
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_firststart_slide2.xml
+++ b/app/src/main/res/layout/activity_firststart_slide2.xml
@@ -3,6 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/bg_screen2"
+    android:paddingBottom="@dimen/dots_full_height"
     android:fillViewport="true">
 
     <LinearLayout

--- a/app/src/main/res/layout/activity_firststart_slide3.xml
+++ b/app/src/main/res/layout/activity_firststart_slide3.xml
@@ -3,7 +3,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/bg_screen3"
-    android:fillViewport="true">
+    android:fillViewport="true"
+    android:paddingBottom="@dimen/dots_full_height">
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_firststart_slide3.xml
+++ b/app/src/main/res/layout/activity_firststart_slide3.xml
@@ -1,26 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/bg_screen3">
+    android:background="@color/bg_screen3"
+    android:fillViewport="true">
 
     <LinearLayout
-        android:background="@color/bg_screen3"
-        android:gravity="center_horizontal"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
+        android:gravity="center"
         android:orientation="vertical">
 
         <TextView
             android:id="@+id/title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/welcome_title"
+            android:layout_margin="30dp"
             android:gravity="center"
+            android:text="@string/welcome_title"
             android:textColor="@android:color/white"
-            android:textSize="30sp"
-            android:layout_margin="30dp" />
+            android:textSize="30sp" />
 
         <ImageView
             android:layout_width="@dimen/img_width_height"
@@ -33,14 +32,14 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"
-            android:paddingEnd="40dp"
-            android:paddingLeft="40dp"
-            android:paddingRight="40dp"
-            android:paddingStart="40dp"
-            android:text="@string/grant_permission"
             android:contentDescription="@string/grant_permission"
-            android:drawableLeft="@android:drawable/ic_menu_mylocation"
             android:drawableStart="@android:drawable/ic_menu_mylocation"
+            android:drawableLeft="@android:drawable/ic_menu_mylocation"
+            android:paddingStart="40dp"
+            android:paddingLeft="40dp"
+            android:paddingEnd="40dp"
+            android:paddingRight="40dp"
+            android:text="@string/grant_permission"
             android:textSize="12sp" />
 
         <TextView
@@ -48,31 +47,24 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"
             android:text="@string/location_permission_title"
+            android:textAlignment="center"
             android:textColor="@android:color/white"
             android:textSize="@dimen/slide_title"
-            android:textStyle="bold"
+            android:textStyle="bold" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="@dimen/desc_marginTop"
+            android:paddingLeft="@dimen/desc_padding"
+            android:paddingRight="@dimen/desc_padding"
+            android:paddingBottom="@dimen/desc_paddingBottom"
+            android:text="@string/location_permission_desc"
             android:textAlignment="center"
-            />
-
-        <ScrollView
-            android:layout_width="match_parent"
-            android:layout_height="match_parent">
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_horizontal"
-                android:layout_marginTop="@dimen/desc_marginTop"
-                android:paddingLeft="@dimen/desc_padding"
-                android:paddingRight="@dimen/desc_padding"
-                android:paddingBottom="@dimen/desc_paddingBottom"
-                android:text="@string/location_permission_desc"
-                android:textAlignment="center"
-                android:textColor="@android:color/white"
-                android:textSize="@dimen/slide_desc" />
-
-        </ScrollView>
+            android:textColor="@android:color/white"
+            android:textSize="@dimen/slide_desc" />
 
     </LinearLayout>
 
-</RelativeLayout>
+</ScrollView>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -6,6 +6,7 @@
     <!-- Default screen margins, per the Android Design guidelines. -->
     <dimen name="dots_height">30dp</dimen>
     <dimen name="dots_margin_bottom">20dp</dimen>
+    <dimen name="dots_full_height">50dp</dimen>
     <dimen name="img_width_height">120dp</dimen>
     <dimen name="slide_title">30sp</dimen>
     <dimen name="slide_desc">16sp</dimen>


### PR DESCRIPTION
Hi!
This PR simplifies welcome wizard layouts. It makes the whole content scrollable. It should make layouts work better on smaller devices.

Fixes #1626.
Fixes #1723.

---

```
<RelativeLayout>
    <LinearLayout>
        <ScrollView>
...
```
becomes:
```
<ScrollView>
    <LinearLayout>
...
```

**Portrait**
Before:
![Screenshot_20211111_195825](https://user-images.githubusercontent.com/1929048/141677908-2719145d-c8e4-4f24-9cc5-0fbabb21e4e1.png)
After:
![Screenshot_20211113_164156](https://user-images.githubusercontent.com/1929048/141677915-ce9cac9e-cc96-45d7-af82-0c02dec8a8a8.png)

**Landscape**
Before:
![Screenshot_20211111_195931](https://user-images.githubusercontent.com/1929048/141677933-42e8d0de-e6f1-433f-9c72-a2dce282364c.png)

After:
![Screenshot_20211113_164235](https://user-images.githubusercontent.com/1929048/141678014-df55a898-883a-4fd5-97fa-37afd8db1b87.png)