### PR TITLE
Improve build speed by reusing computations from previous builds

### DIFF
--- a/docker/prebuild.sh
+++ b/docker/prebuild.sh
@@ -5,6 +5,6 @@
 echo "Prepopulating gradle and go build/pkg cache"
 git clone --recurse-submodules https://github.com/syncthing/syncthing-android
 cd syncthing-android
-./gradlew --no-daemon lint buildNative
+./gradlew --daemon lint buildNative
 cd ..
 rm -rf syncthing-android


### PR DESCRIPTION

[Gradle daemon](https://docs.gradle.org/current/userguide/gradle_daemon.html#header). The Daemon is a long-lived process that help to avoid the cost of JVM startup for every build. Since Gradle 3.0, Gradle daemon is enabled by default. For an older version, you should enable it by setting `org.gradle.daemon=true`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
