### PR TITLE
build: Use python as command (fixes #1783)

### DIFF
--- a/syncthing/build.gradle
+++ b/syncthing/build.gradle
@@ -2,7 +2,7 @@ task buildNative(type: Exec) {
     environment "NDK_VERSION", "$ndkVersionShared"
     inputs.dir("$projectDir/src/")
     outputs.dir("$projectDir/../app/src/main/jniLibs/")
-    executable = 'python3'
+    executable = 'python'
     args = ['-u', './build-syncthing.py']
 }
 


### PR DESCRIPTION
requires https://github.com/syncthing/syncthing-android/pull/1786