### PR TITLE
build: Use gradle plugin to execute python script (fixes #1783)

### DIFF
--- a/syncthing/build.gradle
+++ b/syncthing/build.gradle
@@ -1,9 +1,12 @@
-task buildNative(type: Exec) {
+plugins {
+    id 'ru.vyarus.use-python' version '2.3.0'
+}
+
+task buildNative(type: PythonTask) {
     environment "NDK_VERSION", "$ndkVersionShared"
     inputs.dir("$projectDir/src/")
     outputs.dir("$projectDir/../app/src/main/jniLibs/")
-    executable = 'python3'
-    args = ['-u', './build-syncthing.py']
+    command = "-u ./build-syncthing.py"
 }
 
 /**


### PR DESCRIPTION
Adding a build dependency to handle the executable sometimes being named python and sometimes python3 is not nice, but neither is adding symlinks to our docker to work around it and hope there's no-one only having python3. Fixes #1785 