### PR TITLE
Run without (detected) network

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -104,6 +104,7 @@ public class SettingsActivity extends SyncthingActivity {
         private Preference         mCategoryRunConditions;
         private CheckBoxPreference mStartServiceOnBoot;
         private ListPreference     mPowerSource;
+        private CheckBoxPreference mRunOnNoNetwork;
         private CheckBoxPreference mRunOnMobileData;
         private CheckBoxPreference mRunOnWifi;
         private CheckBoxPreference mRunOnMeteredWifi;
@@ -171,6 +172,8 @@ public class SettingsActivity extends SyncthingActivity {
                     (CheckBoxPreference) findPreference(Constants.PREF_START_SERVICE_ON_BOOT);
             mPowerSource =
                     (ListPreference) findPreference(Constants.PREF_POWER_SOURCE);
+            mRunOnNoNetwork =
+                    (CheckBoxPreference) findPreference(Constants.PREF_RUN_ON_NO_NETWORK);
             mRunOnMobileData =
                     (CheckBoxPreference) findPreference(Constants.PREF_RUN_ON_WIFI);
             mRunOnWifi =

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
@@ -14,6 +14,7 @@ public class Constants {
 
     // Preferences - Run conditions
     public static final String PREF_START_SERVICE_ON_BOOT       = "always_run_in_background";
+    public static final String PREF_RUN_ON_NO_NETWORK           = "run_on_no_network";
     public static final String PREF_RUN_ON_MOBILE_DATA          = "run_on_mobile_data";
     public static final String PREF_RUN_ON_WIFI                 = "run_on_wifi";
     public static final String PREF_RUN_ON_METERED_WIFI         = "run_on_metered_wifi";

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/RunConditionMonitor.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/RunConditionMonitor.java
@@ -170,6 +170,7 @@ public class RunConditionMonitor {
     private RunConditionCheckResult decideShouldRun() {
         // Get run conditions preferences.
         boolean prefRunOnMobileData= mPreferences.getBoolean(Constants.PREF_RUN_ON_MOBILE_DATA, false);
+        boolean prefRunOnNoNetwork= mPreferences.getBoolean(Constants.PREF_RUN_ON_NO_NETWORK, false);
         boolean prefRunOnWifi= mPreferences.getBoolean(Constants.PREF_RUN_ON_WIFI, true);
         boolean prefRunOnMeteredWifi= mPreferences.getBoolean(Constants.PREF_RUN_ON_METERED_WIFI, false);
         Set<String> whitelistedWifiSsids = mPreferences.getStringSet(Constants.PREF_WIFI_SSID_WHITELIST, new HashSet<>());
@@ -212,6 +213,10 @@ public class RunConditionMonitor {
         if (prefRespectMasterSync && !ContentResolver.getMasterSyncAutomatically()) {
             Log.v(TAG, "decideShouldRun: prefRespectMasterSync && !getMasterSyncAutomatically");
             blockerReasons.add(GLOBAL_SYNC_DISABLED);
+        }
+
+        if (blockerReasons.isEmpty() && prefRunOnNoNetwork) {
+            return SHOULD_RUN;
         }
 
         // Run on mobile data.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -321,6 +321,9 @@ Please report any problems you encounter via Github.</string>
     <string name="run_on_mobile_data_title">Run on mobile data</string>
     <string name="run_on_mobile_data_summary">Run when device is connected via the mobile data network. Warning: This can consume a lot of data from your mobile operator data plan if you sync large amounts of data.</string>
 
+    <string name="run_on_no_network_title">Run without (detected) network</string>
+    <string name="run_on_no_network_summary">Run even when no network is detected at all (this might be useful when running over a VPN which sometimes confuses the other run conditions.)</string>
+
     <string name="run_on_wifi_title">Run on Wi-Fi</string>
     <string name="run_on_wifi_summary">Run when device is connected to a Wi-Fi network.</string>
 

--- a/app/src/main/res/xml/app_settings.xml
+++ b/app/src/main/res/xml/app_settings.xml
@@ -20,6 +20,12 @@
             android:summary="@string/run_conditions_summary"/>
 
         <CheckBoxPreference
+            android:key="run_on_no_network"
+            android:title="@string/run_on_no_network_title"
+            android:summary="@string/run_on_no_network_summary"
+            android:defaultValue="false" />
+
+        <CheckBoxPreference
             android:key="run_on_wifi"
             android:title="@string/run_on_wifi_title"
             android:summary="@string/run_on_wifi_summary"


### PR DESCRIPTION
There have been issues like https://github.com/syncthing/syncthing-android/issues/1694 or https://github.com/syncthing/syncthing-android/issues/1280 (and just very recently: https://github.com/syncthing/syncthing-android/issues/1822)

I ran into the same issue on my device (lineageos on sony xa2.) In my case syncthing refuses to run as soon as I start a wireguard tunnel. But instead of opening another ticket i figured I could try adding a workaround myself.

So this pull request adds another run condition entry: "Run without (detected) network" which short circuits the connectivity check.

This has not been tested yet, as I can't find the damn USB cable right now. It compiles and runs on the emulator though. Before going forward with this I wanted to test the waters and see if there is any interest for this at all..