### PR TITLE
add preference to run always (ignore run conditions)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
@@ -14,6 +14,7 @@ public class Constants {
 
     // Preferences - Run conditions
     public static final String PREF_START_SERVICE_ON_BOOT       = "always_run_in_background";
+    public static final String PREF_RUN_CONDITIONS              = "static_run_conditions";
     public static final String PREF_RUN_ON_MOBILE_DATA          = "run_on_mobile_data";
     public static final String PREF_RUN_ON_WIFI                 = "run_on_wifi";
     public static final String PREF_RUN_ON_METERED_WIFI         = "run_on_metered_wifi";

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/RunConditionMonitor.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/RunConditionMonitor.java
@@ -169,6 +169,7 @@ public class RunConditionMonitor {
      */
     private RunConditionCheckResult decideShouldRun() {
         // Get run conditions preferences.
+        boolean prefRunConditions= mPreferences.getBoolean(Constants.PREF_RUN_CONDITIONS, false);
         boolean prefRunOnMobileData= mPreferences.getBoolean(Constants.PREF_RUN_ON_MOBILE_DATA, false);
         boolean prefRunOnWifi= mPreferences.getBoolean(Constants.PREF_RUN_ON_WIFI, true);
         boolean prefRunOnMeteredWifi= mPreferences.getBoolean(Constants.PREF_RUN_ON_METERED_WIFI, false);
@@ -178,6 +179,11 @@ public class RunConditionMonitor {
         String prefPowerSource = mPreferences.getString(Constants.PREF_POWER_SOURCE, POWER_SOURCE_CHARGER_BATTERY);
         boolean prefRespectPowerSaving = mPreferences.getBoolean(Constants.PREF_RESPECT_BATTERY_SAVING, true);
         boolean prefRespectMasterSync = mPreferences.getBoolean(Constants.PREF_RESPECT_MASTER_SYNC, false);
+
+        if (!prefRunConditions) {
+            Log.v(TAG, "decideShouldRun: !runConditions");
+            return SHOULD_RUN;
+        }
 
         List<BlockerReason> blockerReasons = new ArrayList<>();
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -315,7 +315,7 @@ Please report any problems you encounter via Github.</string>
     <string name="category_experimental">Experimental</string>
 
     <!-- Preference screen - Run conditions -->
-    <string name="run_conditions_title">Run Conditions</string>
+    <string name="run_conditions_title">Enable run conditions</string>
     <string name="run_conditions_summary">Use the following options to decide when Syncthing will run.</string>
 
     <string name="run_on_mobile_data_title">Run on mobile data</string>

--- a/app/src/main/res/xml/app_settings.xml
+++ b/app/src/main/res/xml/app_settings.xml
@@ -12,12 +12,11 @@
         android:title="@string/category_run_conditions"
         android:key="category_run_conditions">
 
-        <Preference
+        <CheckBoxPreference
             android:key="static_run_conditions"
-            android:persistent="false"
-            android:selectable="false"
             android:title="@string/run_conditions_title"
-            android:summary="@string/run_conditions_summary"/>
+            android:summary="@string/run_conditions_summary"
+            android:defaultValue="true" />
 
         <CheckBoxPreference
             android:key="run_on_wifi"


### PR DESCRIPTION
As I wrote in the comment https://github.com/syncthing/syncthing-android/pull/1821#issuecomment-1213453291 for https://github.com/syncthing/syncthing-android/pull/1821 it might be useful to have a preference to ignore all run conditions. This PR implements this. Tested in the emulator and seems to work
![run_conditions_enabled](https://user-images.githubusercontent.com/84968/185876403-7513a504-208b-418a-9921-e976e207cb57.PNG)
![run_conditions_disabled](https://user-images.githubusercontent.com/84968/185876420-6fefe600-875f-4bb0-980c-703188f7a0c1.PNG)
.