### PR TITLE
Remove activity from recents list on exit (fixes #1805)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/fragments/DrawerFragment.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/fragments/DrawerFragment.java
@@ -287,6 +287,6 @@ public class DrawerFragment extends Fragment implements View.OnClickListener {
         }
         Log.i(TAG, "Exiting app on user request");
         mActivity.stopService(new Intent(mActivity, SyncthingService.class));
-        mActivity.finish();
+        mActivity.finishAndRemoveTask();
     }
 }

--- a/app/src/main/java/com/nutomic/syncthingandroid/fragments/DrawerFragment.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/fragments/DrawerFragment.java
@@ -287,6 +287,10 @@ public class DrawerFragment extends Fragment implements View.OnClickListener {
         }
         Log.i(TAG, "Exiting app on user request");
         mActivity.stopService(new Intent(mActivity, SyncthingService.class));
-        mActivity.finishAndRemoveTask();
+        if(android.os.Build.VERSION.SDK_INT >= 21) {
+            mActivity.finishAndRemoveTask();
+        } else {
+            mActivity.finish();
+        }
     }
 }


### PR DESCRIPTION
Should fix https://github.com/syncthing/syncthing-android/issues/1805

I just took the recommendation from that issue and tried it. Seems to work fine on my device..