### PR TITLE
Remove copied device ID toast on android 13+

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/util/Util.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/Util.java
@@ -42,8 +42,10 @@ public class Util {
                 context.getSystemService(Context.CLIPBOARD_SERVICE);
         ClipData clip = ClipData.newPlainText(context.getString(R.string.device_id), id);
         clipboard.setPrimaryClip(clip);
-        Toast.makeText(context, R.string.device_id_copied_to_clipboard, Toast.LENGTH_SHORT)
+        if (android.os.Build.VERSION.SDK_INT < 33) {
+            Toast.makeText(context, R.string.device_id_copied_to_clipboard, Toast.LENGTH_SHORT)
                 .show();
+        }
     }
 
     /**

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/Util.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/Util.java
@@ -44,7 +44,7 @@ public class Util {
         clipboard.setPrimaryClip(clip);
         if (android.os.Build.VERSION.SDK_INT < 33) {
             Toast.makeText(context, R.string.device_id_copied_to_clipboard, Toast.LENGTH_SHORT)
-                .show();
+                    .show();
         }
     }
 


### PR DESCRIPTION
>  In Android 12L (API level 32) and lower, we suggest alerting users that they’ve successfully copied by issuing a visual pop-up in-app widget (like Toasts or Snackbars) after copying.
> 
> To avoid duplicate displays of information, we strongly recommend removing any pop-up widget shown after an in-app copy for Android 13 and higher.
> If you show a copy confirmation snackbar in Android 13, the user sees duplicate messages.
> If you show a copy confirmation toast in Android 13, the user sees duplicate messages.
> 


https://developer.android.com/develop/ui/views/touch-and-input/copy-paste#duplicate-notifications


it show duplicate notification on android 13 at the moment:

![Screenshot_20221114-030710_1](https://user-images.githubusercontent.com/109251285/201561610-dae8a0ca-4eaa-402f-a6d5-66b4a7427696.png)
