### PR TITLE
Fix default for global run condition setting (fixes #1852)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/service/RunConditionMonitor.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/RunConditionMonitor.java
@@ -169,7 +169,7 @@ public class RunConditionMonitor {
      */
     private RunConditionCheckResult decideShouldRun() {
         // Get run conditions preferences.
-        boolean prefRunConditions= mPreferences.getBoolean(Constants.PREF_RUN_CONDITIONS, false);
+        boolean prefRunConditions= mPreferences.getBoolean(Constants.PREF_RUN_CONDITIONS, true);
         boolean prefRunOnMobileData= mPreferences.getBoolean(Constants.PREF_RUN_ON_MOBILE_DATA, false);
         boolean prefRunOnWifi= mPreferences.getBoolean(Constants.PREF_RUN_ON_WIFI, true);
         boolean prefRunOnMeteredWifi= mPreferences.getBoolean(Constants.PREF_RUN_ON_METERED_WIFI, false);


### PR DESCRIPTION
I tried to repro #1852 by removing the setting manually while having Syncthing stop. At first I failed, as I just checked what the value in the settings file was after starting Syncthing, and it's always true (good). However if I did the same thing, and disabled wifi and started Syncthing, it did run (bad, as in my run-condition was disregarded). So it seems like the first run-condition check doesn't see the setting, defaults to false (bad) and then later "something" takes the default from the UI definition and writes it to settings. Which is fortunate, as we don't need to do any transition now to set everyone back to the correct default value (and potentially set back a few that aren't default anymore).