### PR TITLE
Compile and target SDK version 31

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,8 +26,8 @@ dependencies {
 
 android {
     // Changes to these values need to be reflected in `../docker/Dockerfile`
-    compileSdkVersion 30
-    buildToolsVersion '30.0.0'
+    compileSdkVersion 31
+    buildToolsVersion '31.0.0'
     ndkVersion = "${ndkVersionShared}"
 
     buildTypes.debug.applicationIdSuffix ".debug"
@@ -40,8 +40,8 @@ android {
     }
     defaultConfig {
         applicationId "com.nutomic.syncthingandroid"
-        minSdkVersion 16
-        targetSdkVersion 30
+        minSdkVersion 21
+        targetSdkVersion 31
         versionCode 4327
         versionName "1.22.2-rc.3"
         testApplicationId 'com.nutomic.syncthingandroid.test'

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/RestApi.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/RestApi.java
@@ -57,6 +57,15 @@ public class RestApi {
 
     private static final String TAG = "RestApi";
 
+    private static final SimpleDateFormat dateFormat;
+    static {
+        if (android.os.Build.VERSION.SDK_INT < 24) {
+            dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        } else {
+            dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
+        }
+    }
+
     /**
      * Compares folders by labels, uses the folder ID as fallback if the label is empty
      */
@@ -276,7 +285,7 @@ public class RestApi {
             remoteIgnoredDevice.deviceID = deviceId;
             remoteIgnoredDevice.address = deviceAddress;
             remoteIgnoredDevice.name = deviceName;
-            remoteIgnoredDevice.time = dateString(new Date());
+            remoteIgnoredDevice.time = dateFormat.format(new Date());
             mConfig.remoteIgnoredDevices.add(remoteIgnoredDevice);
             sendConfig();
             Log.d(TAG, "Ignored device [" + deviceId + "]");
@@ -310,7 +319,7 @@ public class RestApi {
                     IgnoredFolder ignoredFolder = new IgnoredFolder();
                     ignoredFolder.id = folderId;
                     ignoredFolder.label = folderLabel;
-                    ignoredFolder.time = dateString(new Date());
+                    ignoredFolder.time = dateFormat.format(new Date());
                     device.ignoredFolders.add(ignoredFolder);
                     if (BuildConfig.DEBUG) {
                         Log.v(TAG, "device.ignoredFolders = " + new Gson().toJson(device.ignoredFolders));
@@ -716,10 +725,6 @@ public class RestApi {
         synchronized (mConfigLock) {
             mConfig.options = options;
         }
-    }
-
-    private String dateString(Date date) {
-        return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX").format(date);
     }
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,14 +4,14 @@ buildscript {
     ext {
         // Cannot be called "ndkVersion" as that leads to naming collision
         // Changes to this value must be reflected in `./docker/Dockerfile`
-        ndkVersionShared = '23.0.7599858'
+        ndkVersionShared = '23.2.8568313'
     }
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:7.3.1'
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.36.0'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,9 +2,9 @@ FROM openjdk:11
 
 ENV GO_VERSION 1.19.3
 
-ARG ANDROID_SDK_VERSION=7583922
-ARG ANDROID_SDK_FILENAME=commandlinetools-linux-${ANDROID_SDK_VERSION}_latest.zip
-
+# Can be found scrolling down on this page:
+# https://developer.android.com/studio/index.html#command-tools
+ARG ANDROID_SDK_FILENAME=commandlinetools-linux-9123335_latest.zip
 WORKDIR /opt
 
 # Install Go
@@ -26,11 +26,11 @@ ARG SDKMANAGER="${ANDROID_HOME}/cmdline-tools/bin/sdkmanager --sdk_root=${ANDROI
 # Accept the SDK license, as we can't install packages otherwise
 RUN yes | $SDKMANAGER --licenses > /dev/null
 
-# NDK version (r22 fails to build)
-ENV NDK_VERSION 23.0.7599858
+# NDK version
+ENV NDK_VERSION 23.2.8568313
 
 # Install other android packages, including NDK
-RUN $SDKMANAGER tools platform-tools "build-tools;29.0.3" "platforms;android-29" "extras;android;m2repository" "ndk;${NDK_VERSION}"
+RUN $SDKMANAGER tools platform-tools "build-tools;31.0.0" "platforms;android-31" "extras;android;m2repository" "ndk;${NDK_VERSION}"
 
 # Accept licenses of newly installed packages
 RUN yes | $SDKMANAGER --licenses

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip

--- a/syncthing/build-syncthing.py
+++ b/syncthing/build-syncthing.py
@@ -25,7 +25,6 @@ BUILD_TARGETS = [
         'goarch': 'arm64',
         'jni_dir': 'arm64-v8a',
         'cc': 'aarch64-linux-android21-clang',
-        'min_sdk': 21,
     },
     {
         'arch': 'x86',
@@ -38,7 +37,6 @@ BUILD_TARGETS = [
         'goarch': 'amd64',
         'jni_dir': 'x86_64',
         'cc': 'x86_64-linux-android21-clang',
-        'min_sdk': 21,
     }
 ]
 
@@ -88,7 +86,6 @@ subprocess.check_call([
 ])
 
 for target in BUILD_TARGETS:
-    target_min_sdk = str(target.get('min_sdk', min_sdk))
 
     print('Building syncthing for', target['arch'])
 


### PR DESCRIPTION
It's the time of the year again... where gplay decides to reject updates due to target API levels. As usual thanks to @Catfriend1 for already having dealt with that - greping your git history is very helpful :) 

Now there's just one thing that's confusing to me, and that's https://github.com/Catfriend1/syncthing-android/pull/918:

> Problem: Android 12+ doesn't allow to start the foreground service 

From googles page on behaviour changes: https://developer.android.com/about/versions/12/behavior-changes-12#foreground-service-launch-restrictions

> Apps that target Android 12 or higher can't [start foreground services while running in the background](https://developer.android.com/guide/components/foreground-services#background-start-restrictions), except for [a few special cases](https://developer.android.com/guide/components/foreground-services#background-start-restriction-exemptions). If an app attempts to start a foreground service while running in the background, an exception occurs (except for the few special cases).

Well we aren't starting foreground services while in background, are we?  
Everything runs fine for me on Android 12. And even if it didn't, the required change would be large - from the list of reasons to be excempt from that:

> - Apps that target Android 12 or higher can't [start foreground services while running in the background](https://developer.android.com/guide/components/foreground-services#background-start-restrictions), except for [a few special cases](https://developer.android.com/guide/components/foreground-services#background-start-restriction-exemptions). If an app attempts to start a foreground service while running in the background, an exception occurs (except for the few special cases).

@Catfriend1 Could you give some clarification on what's the problem is that you are trying to address in that PR?