### PR TITLE
readme: Update and add detailed steps to build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ Docker, you don't need to set them up separately.
         sure that the version numbers are up-to-date.
 2. Go (see https://docs.syncthing.net/dev/building#prerequisites for the
    required version)
-3. Java version 11
+3. Java version 11 (if not present in ``$PATH``, you might need to set
+   ``$JAVA_HOME`` accordingly)
 4. Python version 3
 
 ## Build instructions

--- a/README.md
+++ b/README.md
@@ -20,20 +20,62 @@ Language mappings are defined in `.tx/config`, with the second code being the on
 
 # Building
 
-### Dependencies
-- Android SDK, with `$ANDROID_HOME` pointing to it (you can skip this if you are using Android Studio)
-- Android NDK (you should install the required version (`ext.ndkVersionShared` in `./build.gradle`) with the usual tools, such that it's located within `$ANDROID_HOME/ndk/`).
-- Go (see [here](https://docs.syncthing.net/dev/building.html#prerequisites) for the required version)
-- Java Version 11 (you scan skip this if you are using Android Studio, otherwise you might need to set `$JAVA_HOME` accordingly)
+## Dependencies
 
-### Build instructions
+These are necessary for building from the command line. If you build using
+Docker, you don't need to set them up separately.
 
-Make sure you clone the project with
-`git clone https://github.com/syncthing/syncthing-android.git --recursive`. Alternatively, run
-`git submodule init && git submodule update` in the project folder.
+1. Android SDK and NDK
+    1. Download SDK command line tools from https://developer.android.com/studio#command-line-tools-only.
+    2. Unpack the downloaded archive to an empty folder. This path is going
+       to become your `ANDROID_HOME` folder.
+    3. Inside the unpacked `cmdline-tools`folder, create yet another folder
+       called `latest`, then move everything else inside it, so that the final
+       folder hierarchy looks as follows.
+       ```
+       cmdline-tools/latest/bin
+       cmdline-tools/latest/lib
+       cmdline-tools/latest/source.properties
+       cmdline-tools/latest/NOTICE.txt
+       ```
+    4. Navigate inside `cmdline-tools/latest/bin`, then execute
+       ```
+       ./sdkmanager "platform-tools" "build-tools;31.0.0" "platforms;android-31" "extras;android;m2repository" "ndk;25.1.8937393"
+       ```
+       The required tools and NDK will be downloaded automatically.
 
-Build Syncthing using `./gradlew buildNative`. Then use `./gradlew assembleDebug` or
-Android Studio to build the apk.
+        **NOTE:** You can double-check [Dockerfile](docker/Dockerfile) to make
+        sure that the version numbers are up-to-date.
+2. Go (see https://docs.syncthing.net/dev/building#prerequisites for the
+   required version)
+3. Java version 11
+4. Python version 3
+
+## Build instructions
+
+### Command line
+
+1. Clone the project with
+   ```
+   git clone https://github.com/syncthing/syncthing-android.git --recursive
+   ```
+   Alternatively, if already present on the disk, run
+   ```
+   git submodule init && git submodule update
+   ```
+   in the project folder.
+2. Make sure that the `ANDROID_HOME` environment variable is set to the path
+   containing the Android SDK (see [Dependecies](#dependencies)).
+3. Navigate inside `syncthing-android`, then build the APK file with
+   ```
+   ./gradlew buildNative
+   ./gradlew assembleDebug
+   ```
+4. Once completed, `app-debug.apk` will be present inside `app/build/outputs/apk/debug`.
+
+**NOTE:** On Windows, you must use the Command Prompt (and not PowerShell) to
+compile. When doing so, in the commands replace all forward slashes `/` with
+backslashes `\`.
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ Language mappings are defined in `.tx/config`, with the second code being the on
 
 # Building
 
-## Dependencies
-
 These are necessary for building from the command line. If you build using
-Docker, you don't need to set them up separately.
+Docker or Android Studio, you don't need to set them up separately.
+
+## Dependencies
 
 1. Android SDK and NDK
     1. Download SDK command line tools from https://developer.android.com/studio#command-line-tools-only.
@@ -53,8 +53,6 @@ Docker, you don't need to set them up separately.
 4. Python version 3
 
 ## Build instructions
-
-### Command line
 
 1. Clone the project with
    ```

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ Language mappings are defined in `.tx/config`, with the second code being the on
 
 # Building
 
-These are necessary for building from the command line. If you build using
-Docker or Android Studio, you don't need to set them up separately.
+These dependencies and instructions are necessary for building from the command
+line. If you build using Docker or Android Studio, you don't need to set up and
+follow them separately.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Docker, you don't need to set them up separately.
     1. Download SDK command line tools from https://developer.android.com/studio#command-line-tools-only.
     2. Unpack the downloaded archive to an empty folder. This path is going
        to become your `ANDROID_HOME` folder.
-    3. Inside the unpacked `cmdline-tools`folder, create yet another folder
+    3. Inside the unpacked `cmdline-tools` folder, create yet another folder
        called `latest`, then move everything else inside it, so that the final
        folder hierarchy looks as follows.
        ```

--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ Docker, you don't need to set them up separately.
        ```
     4. Navigate inside `cmdline-tools/latest/bin`, then execute
        ```
-       ./sdkmanager "platform-tools" "build-tools;31.0.0" "platforms;android-31" "extras;android;m2repository" "ndk;25.1.8937393"
+       ./sdkmanager "platform-tools" "build-tools;<version>" "platforms;android-<version>" "extras;android;m2repository" "ndk;<version>"
        ```
        The required tools and NDK will be downloaded automatically.
 
-        **NOTE:** You can double-check [Dockerfile](docker/Dockerfile) to make
-        sure that the version numbers are up-to-date.
+        **NOTE:** You should check [Dockerfile](docker/Dockerfile) for the
+        specific version numbers to insert in the command above.
 2. Go (see https://docs.syncthing.net/dev/building#prerequisites for the
    required version)
 3. Java version 11 (if not present in ``$PATH``, you might need to set


### PR DESCRIPTION
Currently, the build instructions are very brief and don't explain the whole process of setting up the build environment in detail. Thus, add explicit steps on how to download required tools and prepare then for compilation.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>