### PR TITLE
Declare start/stop intents as exported

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -135,7 +135,7 @@
         </receiver>
         <receiver android:name=".receiver.AppConfigReceiver"
             tools:ignore="ExportedReceiver"
-            android:exported="false">
+            android:exported="true">
             <intent-filter>
                 <action android:name="com.nutomic.syncthingandroid.action.START" />
                 <action android:name="com.nutomic.syncthingandroid.action.STOP" />


### PR DESCRIPTION
Issue reported here: https://forum.syncthing.net/t/android-syncthing-intents-no-longer-working-1-22-2-rc-3/19409/2

Those intent's aren't working anymore in the newest RC. Most likely because I declared them as not exported, mistakenly.