### PR TITLE
Bump SDK to 32

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,8 +26,8 @@ dependencies {
 
 android {
     // Changes to these values need to be reflected in `../docker/Dockerfile`
-    compileSdkVersion 31
-    buildToolsVersion '31.0.0'
+    compileSdkVersion 32
+    buildToolsVersion '32.0.0'
     ndkVersion = "${ndkVersionShared}"
 
     buildTypes.debug.applicationIdSuffix ".debug"
@@ -36,7 +36,7 @@ android {
     defaultConfig {
         applicationId "com.nutomic.syncthingandroid"
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 32
         versionCode 4337
         versionName "1.23.3-rc.1"
         testApplicationId 'com.nutomic.syncthingandroid.test'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,7 +30,7 @@ RUN yes | $SDKMANAGER --licenses > /dev/null
 ENV NDK_VERSION 25.1.8937393
 
 # Install other android packages, including NDK
-RUN $SDKMANAGER tools platform-tools "build-tools;31.0.0" "platforms;android-31" "extras;android;m2repository" "ndk;${NDK_VERSION}"
+RUN $SDKMANAGER tools platform-tools "build-tools;32.0.0" "platforms;android-32" "extras;android;m2repository" "ndk;${NDK_VERSION}"
 
 # Accept licenses of newly installed packages
 RUN yes | $SDKMANAGER --licenses

--- a/docker/prebuild.sh
+++ b/docker/prebuild.sh
@@ -5,6 +5,6 @@
 echo "Prepopulating gradle and go build/pkg cache"
 git clone --recurse-submodules https://github.com/syncthing/syncthing-android
 cd syncthing-android
-./gradlew --no-daemon lint buildNative
+./gradlew --no-daemon lint build
 cd ..
 rm -rf syncthing-android


### PR DESCRIPTION
This is just a "minor" upgrade for android "12L" - some tablet related improvements we likely don't care about. This bump is to support a contribution to migrate our UI from something legacy to an up-to-date default framework that requires >=32.