### PR TITLE
Explain maintenance status and feature request rejection in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,24 @@ A wrapper of [Syncthing](https://github.com/syncthing/syncthing) for Android.
 
 [<img alt="Get it on Google Play" src="https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png" height="80">](https://play.google.com/store/apps/details?id=com.nutomic.syncthingandroid) [<img alt="Get it on F-Droid" src="https://f-droid.org/badge/get-it-on.png" height="80">](https://f-droid.org/app/com.nutomic.syncthingandroid)
 
+# Status: "Maintenance mode" - Co-maintainers welcome
+
+tl;dr: The app is still kept up to date, and contributions are still welcome -
+however even reviews for those can take a long time. Co-maintainers are very
+welcome - get in touch if you are interested.
+
+No-one is dedicating significant time into development or reviews. It's still
+kept up to date with Syncthing, Android and dependencies under the wider
+Syncthing project umbrella on a best effort basis. Contributions are reviewed,
+however available time for that is scarce so it will take a while. And obviously it
+depends both on the size/clarity of the change and (admittedly subjective)
+relevance of it - chance of successful and speedier reviews is higher if your
+change is targeted and small.
+
+## No feature request taken (feature contributions case-by-case)
+
+Handling feature requests use up the little time that is present to keep the app up-to-date, and there is no feature development happening. So unless you are opening a feature request to discuss your own contribution before jumping into coding, the request will be closed directly with some template answer pointing at this section.
+
 # Translations
 
 The project is translated on [Transifex](https://www.transifex.com/projects/p/syncthing-android/).


### PR DESCRIPTION
Maybe we get lucky and someone steps up. And also if not it would at least be possible to see what the state of the project is for anyone who cares to read it, and makes dealing with new feature request simpler/faster. The time I spend on keeping the app alife isn't huge, but it's still quite a few hours every now and then when some upgrade breaks things. And I would like to keep doing that, too many people are using it, but I also have zero energy to engage with feature requests (while I know tons of things that are 1000x more important that I'd address if I ever had the time/energy). And closing them with a documented reason feels better than just ignoring and accumulating tickets.