### PR TITLE
feat: :sparkles: add syncthing uri

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,11 +14,11 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.READ_SYNC_SETTINGS" />
-    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <!-- ACCESS_COARSE_LOCATION is required to get WiFi's SSID on 8.1 -->
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <!-- FOREGROUND_SERVICE is required to create a foreground service on 9 -->
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <!-- ACCESS_FINE_LOCATION is required to get WiFi's SSID on 10 "Q" -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <!-- ACCESS_BACKGROUND_LOCATION is required to get WiFi's SSID on 10 "Q" -->
@@ -43,13 +43,14 @@
         android:requestLegacyExternalStorage="true"
         android:name=".SyncthingApp">
         <activity
-                android:name=".activities.FirstStartActivity"
-                android:label="@string/app_name"
-                android:launchMode="singleTask"
+            android:name=".activities.FirstStartActivity"
+            android:label="@string/app_name"
+            android:launchMode="singleTask"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+                <data android:scheme="syncthing" android:host="open" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
Hi there, I'm currently working on a [Syncthing integration for Obsidian](https://github.com/LBF38/obsidian-syncthing-integration) and I am having trouble to launch the Syncthing app from within [Obsidian](https://obsidian.md/).

Therefore, I would love to add some syncthing URIs to launch certain activities of the app.

In this PR, I'm adding a URI to open the app from the URI `syncthing://open`.
If possible, it would be awesome to also have `syncthing://start` and `syncthing://stop` to be able to start or stop Syncthing services from the Obsidian plugin I'm developing.

Purpose of this PR : 
- add a `syncthing://open` uri to open the syncthing app from another app.
