### PR TITLE
Fix release workflow tag patterns

### DIFF
--- a/.github/workflows/build-app.yaml
+++ b/.github/workflows/build-app.yaml
@@ -6,7 +6,8 @@ on:
     # Cannot filter on both branches (release) and tags - it's ORed
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
-      - '[0-9]+.[0-9]+.[0-9]+-rc\.[0-9]+(\.[0-9]+)?'
+      - '[0-9]+.[0-9]+.[0-9]+-rc\.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-rc\.[0-9]+\.[0-9]+'
 
 env:
   # Our build metadata


### PR DESCRIPTION
Clearly they aren't regex, so no optional groups (apparently not so clearly).

So much for not debugging on main.