### PR TITLE
Remove non-functional restartOnWakeup from app settings (fixes #1961)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -126,7 +126,6 @@ public class SettingsActivity extends SyncthingActivity {
         private CheckBoxPreference mRelaysEnabled;
         private EditTextPreference mGlobalAnnounceServers;
         private EditTextPreference mAddress;
-        private CheckBoxPreference mRestartOnWakeup;
         private CheckBoxPreference mUrAccepted;
 
         private Preference mCategoryBackup;
@@ -214,7 +213,6 @@ public class SettingsActivity extends SyncthingActivity {
             mRelaysEnabled          = (CheckBoxPreference) findPreference("relaysEnabled");
             mGlobalAnnounceServers  = (EditTextPreference) findPreference("globalAnnounceServers");
             mAddress                = (EditTextPreference) findPreference("address");
-            mRestartOnWakeup        = (CheckBoxPreference) findPreference("restartOnWakeup");
             mUrAccepted             = (CheckBoxPreference) findPreference("urAccepted");
 
             mCategoryBackup         = findPreference("category_backup");
@@ -352,7 +350,6 @@ public class SettingsActivity extends SyncthingActivity {
             mRelaysEnabled.setChecked(mOptions.relaysEnabled);
             mGlobalAnnounceServers.setText(joiner.join(mOptions.globalAnnounceServers));
             mAddress.setText(mGui.address);
-            mRestartOnWakeup.setChecked(mOptions.restartOnWakeup);
             mApi.getSystemInfo(systemInfo ->
                     mUrAccepted.setChecked(mOptions.isUsageReportingAccepted(systemInfo.urVersionMax)));
         }
@@ -456,9 +453,6 @@ public class SettingsActivity extends SyncthingActivity {
                     break;
                 case "address":
                     mGui.address = (String) o;
-                    break;
-                case "restartOnWakeup":
-                    mOptions.restartOnWakeup = (boolean) o;
                     break;
                 case "urAccepted":
                     mApi.getSystemInfo(systemInfo -> {

--- a/app/src/main/java/com/nutomic/syncthingandroid/model/Options.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/model/Options.java
@@ -22,7 +22,6 @@ public class Options {
     public String urURL;
     public boolean urPostInsecurely;
     public int urInitialDelayS;
-    public boolean restartOnWakeup;
     public int autoUpgradeIntervalH;
     public int keepTemporariesH;
     public boolean cacheIgnoredFiles;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -478,10 +478,6 @@ Please report any problems you encounter via Github.</string>
 
     <string name="use_legacy_hashing_summary">Force Syncthing to use legacy hashing package for compatibility purposes</string>
 
-    <string name="restart_on_wakeup_title">Restart on Wakeup</string>
-
-    <string name="restart_on_wakeup_summary">Default: Enabled. Disabling this feature may result in folder scans and device reconnects being delayed to save battery.</string>
-
     <!-- Dialog shown before config export -->
     <string name="dialog_confirm_export">Do you really want to export your configuration? Existing files will be overwritten.\n\nWARNING! Other applications may be able to read the private key from the backup location and use it to download/modify synchronized files.</string>
 

--- a/app/src/main/res/xml/app_settings.xml
+++ b/app/src/main/res/xml/app_settings.xml
@@ -167,12 +167,6 @@
             android:inputType="textNoSuggestions" />
 
         <CheckBoxPreference
-            android:key="restartOnWakeup"
-            android:title="@string/restart_on_wakeup_title"
-            android:summary="@string/restart_on_wakeup_summary"
-            android:defaultValue="false" />
-
-        <CheckBoxPreference
             android:key="urAccepted"
             android:title="@string/usage_reporting"
             android:persistent="false" />


### PR DESCRIPTION
Remove non-functional restartOnWakeup from app settings (fixes #1961)

The option "restartOnWakeup" was removed in Syncthing v1.21.0 [1]. Thus,
remove it from the Android app as well, since the option does not
perform any function anymore. In addition, update the Docs also [2].

[1] https://github.com/syncthing/syncthing/issues/8448
[2] https://github.com/syncthing/docs/pull/815

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>