### PR TITLE
Fix status bar text and icons color in light mode (fixes #1963)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FirstStartActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FirstStartActivity.java
@@ -93,12 +93,6 @@ public class FirstStartActivity extends Activity {
             return;
         }
 
-        // Make notification bar transparent (API level 21+)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE |
-                View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
-        }
-
         // Show first start welcome wizard UI.
         setContentView(R.layout.activity_first_start);
         mViewPager = (ViewPager) findViewById(R.id.view_pager);
@@ -118,9 +112,6 @@ public class FirstStartActivity extends Activity {
         // Add bottom dots
         addBottomDots();
         setActiveBottomDot(0);
-
-        // Make notification bar transparent
-        changeStatusBarColor();
 
         mViewPagerAdapter = new ViewPagerAdapter();
         mViewPager.setAdapter(mViewPagerAdapter);
@@ -287,17 +278,6 @@ public class FirstStartActivity extends Activity {
 
         }
     };
-
-    /**
-     * Making notification bar transparent
-     */
-    private void changeStatusBarColor() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            Window window = getWindow();
-            window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
-            window.setStatusBarColor(Color.TRANSPARENT);
-        }
-    }
 
     /**
      * View pager adapter

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -2,6 +2,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
     <style name="Theme.Syncthing" parent="Theme.Syncthing.Base">
+        <item name="android:windowLightStatusBar" tools:targetApi="m">false</item>
         <item name="android:windowLightNavigationBar" tools:ignore="NewApi">false</item>
     </style>
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -28,10 +28,13 @@
 
         <item name="android:statusBarColor" tools:targetApi="m">@android:color/transparent</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>
+
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:windowIsTranslucent">false</item>
     </style>
 
     <style name="Theme.Syncthing" parent="Theme.Syncthing.Base">
-        <item name="android:windowLightStatusBar" tools:targetApi="m">false</item>
+        <item name="android:windowLightStatusBar" tools:targetApi="m">true</item>
         <item name="android:windowLightNavigationBar" tools:ignore="NewApi">true</item>
     </style>
 


### PR DESCRIPTION
closes #1963

PS: This one has been kinda ugly to spot, ngl. I didn't expect that we were modifying the welcome activity status bar color programmatically instead of just with an XML theme ...