### PR TITLE
Remove non-functional restartOnWakeup from app settings (fixes #1961)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -126,7 +126,6 @@ public class SettingsActivity extends SyncthingActivity {
         private CheckBoxPreference mRelaysEnabled;
         private EditTextPreference mGlobalAnnounceServers;
         private EditTextPreference mAddress;
-        private CheckBoxPreference mRestartOnWakeup;
         private CheckBoxPreference mUrAccepted;
 
         private Preference mCategoryBackup;
@@ -214,7 +213,6 @@ public class SettingsActivity extends SyncthingActivity {
             mRelaysEnabled          = (CheckBoxPreference) findPreference("relaysEnabled");
             mGlobalAnnounceServers  = (EditTextPreference) findPreference("globalAnnounceServers");
             mAddress                = (EditTextPreference) findPreference("address");
-            mRestartOnWakeup        = (CheckBoxPreference) findPreference("restartOnWakeup");
             mUrAccepted             = (CheckBoxPreference) findPreference("urAccepted");
 
             mCategoryBackup         = findPreference("category_backup");
@@ -352,7 +350,6 @@ public class SettingsActivity extends SyncthingActivity {
             mRelaysEnabled.setChecked(mOptions.relaysEnabled);
             mGlobalAnnounceServers.setText(joiner.join(mOptions.globalAnnounceServers));
             mAddress.setText(mGui.address);
-            mRestartOnWakeup.setChecked(mOptions.restartOnWakeup);
             mApi.getSystemInfo(systemInfo ->
                     mUrAccepted.setChecked(mOptions.isUsageReportingAccepted(systemInfo.urVersionMax)));
         }
@@ -456,9 +453,6 @@ public class SettingsActivity extends SyncthingActivity {
                     break;
                 case "address":
                     mGui.address = (String) o;
-                    break;
-                case "restartOnWakeup":
-                    mOptions.restartOnWakeup = (boolean) o;
                     break;
                 case "urAccepted":
                     mApi.getSystemInfo(systemInfo -> {

--- a/app/src/main/java/com/nutomic/syncthingandroid/model/Options.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/model/Options.java
@@ -22,7 +22,6 @@ public class Options {
     public String urURL;
     public boolean urPostInsecurely;
     public int urInitialDelayS;
-    public boolean restartOnWakeup;
     public int autoUpgradeIntervalH;
     public int keepTemporariesH;
     public boolean cacheIgnoredFiles;

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -303,8 +303,6 @@
   <string name="toast_invalid_http_proxy_address">Невалиден синтаксис за прокси \'http://[IP/HOSTNAME]:[PORT]\'</string>
   <string name="use_legacy_hashing_title">Стари отпечатъци</string>
   <string name="use_legacy_hashing_summary">Принуждава Syncthing да използва по-стария пакет за отпечатъци с цел съвместимост</string>
-  <string name="restart_on_wakeup_title">Рестартиране при Събуждане</string>
-  <string name="restart_on_wakeup_summary">Стандартно: Включено. Ако изключите опцията сканирането и свързването с устройства ще бъдат отложени, с цел запазване на батерията.</string>
   <!--Dialog shown before config export-->
   <string name="dialog_confirm_export">Наистина ли желаете настройките да бъдат изнесени? Съществуващите файлове ще бъдат презаписани.\n\nВНИМАНИЕ! Други приложения могат да извлекат частния ключ от изнесения файл, а чрез него да изтеглят и синхронизират файлове.</string>
   <!--Dialog shown before config import-->

--- a/app/src/main/res/values-ca-rES/strings.xml
+++ b/app/src/main/res/values-ca-rES/strings.xml
@@ -296,8 +296,6 @@ Ens podeu informar dels problemes que trobeu a través de Github.</string>
   <string name="toast_invalid_http_proxy_address">No compleix la sintaxi de proxy \'http://[IP/HOSTNAME]:[PORT]\'</string>
   <string name="use_legacy_hashing_title">Genera els hash amb el sistema antic</string>
   <string name="use_legacy_hashing_summary">Es forçarà el Syncthing a utilitzar el paquet de hashing antic per compatibilitat</string>
-  <string name="restart_on_wakeup_title">Reinicia en despertar-se</string>
-  <string name="restart_on_wakeup_summary">Per defecte: Activat. Si es desactiva pot provocar retards en la comprovació de carpetes i reconnexions del dispositiu per estalviar bateria.</string>
   <!--Dialog shown before config export-->
   <string name="dialog_confirm_export">Realment voleu exportar la configuració? Es sobreescriuran els fitxers existents.\n\nAVÍS! Altres aplicacions podrien llegir la clau privada emmagatzemada a la còpia de seguretat i utilitzar-la per descarregar o modificar fitxers sincronitzats.</string>
   <!--Dialog shown before config import-->

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -305,8 +305,6 @@ Všechny zaznamenané chyby prosím hlašte přes Github.</string>
   <string name="toast_invalid_http_proxy_address">Vstup neodpovídá syntaxi proxy „http://[IP/HOSTNAME]:[PORT]“</string>
   <string name="use_legacy_hashing_title">Používat standardní kontrolní součet</string>
   <string name="use_legacy_hashing_summary">Vynutit použití původního hashovacího algoritmu pro lepší kompatibilitu</string>
-  <string name="restart_on_wakeup_title">Restartovat při probuzení</string>
-  <string name="restart_on_wakeup_summary">Výchozí stav: povoleno. Pokud je tato funkce zakázána, může být skenování zařízení a složek opožděno kvůli výdrži baterie.</string>
   <!--Dialog shown before config export-->
   <string name="dialog_confirm_export">Opravdu chcete exportovat svou konfiguraci? Existující soubory budou přepsány.\n\nVAROVÁNÍ! Ostatní aplikace budou moci číst váš soukromý klíč ze zálohy a použít ho ke stahování/úpravám synchronizovaných souborů.</string>
   <!--Dialog shown before config import-->

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -303,8 +303,6 @@ Vær venlig at rapportere ethvert problem, du støder på, via Github. </string>
   <string name="toast_invalid_http_proxy_address">Input er i strid med proxy syntax \'http://[IP/HOSTNAME]:[PORT]\'</string>
   <string name="use_legacy_hashing_title">Brug legacy hashing</string>
   <string name="use_legacy_hashing_summary">Tving Syncthing til at bruge legacy hashing pakken af kompatibilitetsgrunde </string>
-  <string name="restart_on_wakeup_title">Genstart ved opvågning</string>
-  <string name="restart_on_wakeup_summary">Standard: Aktiveret. Hvis denne funktion er deaktiveret, kan det medføre, at mappescanninger og forbindelsesgenopretning til enheden forsinkes for at spare på batteriet.</string>
   <!--Dialog shown before config export-->
   <string name="dialog_confirm_export">Ønsker du virkelig at eksportere dine konfigurationer? Eksisterende filer vil gå tabt.\n\nADVARSEL! Andre applikationer kan måske læse den private nøgle fra backup lokationen og bruge denne til at downloade/modificere synkroniserede filer.</string>
   <!--Dialog shown before config import-->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -303,8 +303,6 @@ Bitte melde alle auftretenden Probleme via GitHub.</string>
   <string name="toast_invalid_http_proxy_address">Die Eingabe entspricht nicht der Form \'http://[IP/HOSTNAME]:[PORT]\'.</string>
   <string name="use_legacy_hashing_title">Veraltetes Hashing verwenden</string>
   <string name="use_legacy_hashing_summary">Aus Gründen der Abwärtskompatibilität soll Syncthing die alten Hashfunktionen verwenden</string>
-  <string name="restart_on_wakeup_title">Neustart nach Aufwachen</string>
-  <string name="restart_on_wakeup_summary">Standard: Aktiviert. Das Deaktivieren dieser Funktion kann verzögertes Ordner-Scannen und Wiederverbinden von Geräten zur Folge haben. Dafür spart es Akku.</string>
   <!--Dialog shown before config export-->
   <string name="dialog_confirm_export">Soll die Konfiguration wirklich exportiert werden? Vorhandene Dateien werden überschrieben.\n\nACHTUNG! Andere Anwendungen können möglicherweise den privaten Schlüssel im Backupverzeichnis lesen und dazu verwenden, synchronisierte Dateien herunterzuladen und zu verändern.</string>
   <!--Dialog shown before config import-->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -304,8 +304,6 @@ Si encuentras un problema, te pedimos que des aviso a través de GitHub.</string
   <string name="toast_invalid_http_proxy_address">Lo introducido infringe la sintaxis de proxy \'http://[IP/HOSTNAME]:[PORT]\'</string>
   <string name="use_legacy_hashing_title">Utilizar método antiguo para generar los hash</string>
   <string name="use_legacy_hashing_summary">Forzar el uso de un paquete de hashing antiguo por compatibilidad</string>
-  <string name="restart_on_wakeup_title">Reiniciar al Despertar</string>
-  <string name="restart_on_wakeup_summary">Por defecto: Activado. Desactivar esta característica puede provocar que los escaneos de las carpetas y las conexiones de los dispositivos se retrasen para ahorrar batería.</string>
   <!--Dialog shown before config export-->
   <string name="dialog_confirm_export">¿Realmente quieres exportar tu configuración? Se sobreescribirán los ficheros existentes.\n\n¡ADVERTENCIA! Otras aplicaciones podrían leer la clave privada localizada en la ubicación de la copia y usarla para descargar/modificar ficheros sincronizados.</string>
   <!--Dialog shown before config import-->

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -301,8 +301,6 @@
   <string name="toast_invalid_http_proxy_address">Sarrerak proxyaren sintaxia urratzen du \'http://[IP/HOSTNAME]:[PORT]\'</string>
   <string name="use_legacy_hashing_title">Erabili era zaharra hashak sortzeko</string>
   <string name="use_legacy_hashing_summary">Behartu antzinako hashing pakete baten erabilera, bateragarritasunagatik</string>
-  <string name="restart_on_wakeup_title">Esnatzean berrabiarazi</string>
-  <string name="restart_on_wakeup_summary">Balio lehenetsia: gaitua. Funtzio honen desaktibazioa eskaneatze bidez lor daiteke, eta gailuaren birkonexioak atzeratu egiten dira bateria aurrezteko.</string>
   <!--Dialog shown before config export-->
   <string name="dialog_confirm_export">Ziur konfigurazioa esportatu nahi duzula? Dauden fitxategiak gainidatziko dira. Beste aplikazio batzuek kopiaren kokapenean dagoen gako pribatua irakur dezakete eta fitxategi sinkronizatuak deskargatzeko/aldatzeko erabili.</string>
   <!--Dialog shown before config import-->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -304,8 +304,6 @@ S\'il vous plaît, soumettez les problèmes que vous rencontrez via Github.</str
   <string name="toast_invalid_http_proxy_address">L\'entrée ne respecte pas la syntaxe du proxy \'http://[IP/HOSTNAME]:[PORT]\'</string>
   <string name="use_legacy_hashing_title">Utiliser le hachage habituel</string>
   <string name="use_legacy_hashing_summary">Force Syncthing à utiliser le hachage d\'origine pour des raisons de compatibilité.</string>
-  <string name="restart_on_wakeup_title">Redémarrer en cas de réveil</string>
-  <string name="restart_on_wakeup_summary">Par défaut: Activé. La désactivation de cette fonction, pour économiser la batterie, peut entraîner des retards dans l\'analyse des partages et dans la reconnexion des appareils.</string>
   <!--Dialog shown before config export-->
   <string name="dialog_confirm_export">Voulez-vous vraiment exporter votre configuration ? Les fichiers existants seront écrasés.\n\n ATTENTION ! D\'autres applications pourraient lire la clé privée située à l\'emplacement de sauvegarde et l\'utiliser pour télécharger/modifier les fichiers synchronisés.</string>
   <!--Dialog shown before config import-->

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -309,8 +309,6 @@ Néhány eszközön extra alkalmazás-leállító alkalmazást telepített fel a
   <string name="toast_invalid_http_proxy_address">A bemenet sérti a proxy szintaxist \'http://[IP/HOSTNAME]:[PORT]\'</string>
   <string name="use_legacy_hashing_title">Régi típusú hashing használata</string>
   <string name="use_legacy_hashing_summary">Régi típusú hashing használatának kényszerítése kompatibilitási okokból </string>
-  <string name="restart_on_wakeup_title">Újraindítás felébresztéskor</string>
-  <string name="restart_on_wakeup_summary">Alapértelmezés: bekapcsolva. A funckió bekapcsolása a mappák szkennelésének és az eszközök újracsatlakozásának késleltetését okozza az akkumulátor kímélése érdekében.</string>
   <!--Dialog shown before config export-->
   <string name="dialog_confirm_export">Biztosan exportálni szeretnéd a konfigurációt? A már létező fájlok felül lesznek írva.
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -304,8 +304,6 @@ Si prega di segnalare eventuali problemi che si incontrano via Github.</string>
   <string name="toast_invalid_http_proxy_address">Il dato inserito viola la sintassi del proxy \'http://[IP/HOSTNAME]:[PORT]\'</string>
   <string name="use_legacy_hashing_title">Utilizza la funzione di hash precedente</string>
   <string name="use_legacy_hashing_summary">Forza Syncthing ad utilizzare il pacchetto di hash precedente per scopi di compatibilità</string>
-  <string name="restart_on_wakeup_title">Riavvio alla Riattivazione</string>
-  <string name="restart_on_wakeup_summary">Predefinito: Abilitato. La disattivazione di questa funzione può comportare il rallentamento delle scansioni delle cartelle e il ricollegamento dei dispositivi per risparmiare la batteria.</string>
   <!--Dialog shown before config export-->
   <string name="dialog_confirm_export">Vuoi veramente esportare la tua configurazione? I files esistenti verranno sovrascritti.\n\nATTENZIONE! Le altre applicazioni potrebbero essere in grado di leggere la chiave privata dalla locazione di backup e usarla per scaricare/modificare i files sincronizzati.</string>
   <!--Dialog shown before config import-->

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -300,8 +300,6 @@
   <string name="toast_invalid_http_proxy_address">入力されたプロキシ設定は間違っています \'http://[IPアドレス/ホスト名]:[ポート番号]\'</string>
   <string name="use_legacy_hashing_title">レガシーハッシュを使用する</string>
   <string name="use_legacy_hashing_summary">互換性のため従来のハッシュパッケージの使用を強制</string>
-  <string name="restart_on_wakeup_title">ウェイクアップ時に再起動</string>
-  <string name="restart_on_wakeup_summary">デフォルト: 有効。 この機能を無効にすると、バッテリを節約するためにフォルダーのスキャンとデバイスの再接続が遅くなることがあります。</string>
   <!--Dialog shown before config export-->
   <string name="dialog_confirm_export">設定をエクスポートしてもよろしいですか? 既存のファイルは上書きされます。\n\n警告! 他のアプリケーションが、バックアップ先の秘密鍵を読み取り、同期したファイルをダウンロード/変更するために使用することができるかもしれません。</string>
   <!--Dialog shown before config import-->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -293,8 +293,6 @@ Meld eventuele problemen die u tegenkomt op onze GitHub.</string>
   <string name="toast_invalid_http_proxy_address">U heeft een onjuiste proxysyntax opgegeven \'http://[IP/HOSTNAAM]:[POORT]\'</string>
   <string name="use_legacy_hashing_title">Verouderde hashing gebruiken</string>
   <string name="use_legacy_hashing_summary">Dwing Syncthing om het verouderd hashingpakket te gebruiken om compatibiliteitsredenen</string>
-  <string name="restart_on_wakeup_title">Herstarten bij ontwaken</string>
-  <string name="restart_on_wakeup_summary">Dit is standaard ingeschakeld. Als u deze functie uitschakelt, kan dat ertoe leiden dat het scannen van mappen en verbinden met apparaten uitgesteld wordt om accu te besparen.</string>
   <!--Dialog shown before config export-->
   <string name="dialog_confirm_export">Weet u zeker dat u de instellingen wilt exporteren? Bestaande bestanden worden overschreven.\n\WAARSCHUWING: andere apps kunnen mogelijkerwijs bij de geheime sleutel van de back-up en gesynchroniseerde bestanden downloaden/aanpassen.</string>
   <!--Dialog shown before config import-->

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -296,8 +296,6 @@ UWAGA: może to spowodować znaczne zużycie transferu danych</string>
   <string name="toast_invalid_http_proxy_address">Podana wartość nie zgadza się ze składnią: \'http://[IP/HOSTNAME]:[PORT]\'</string>
   <string name="use_legacy_hashing_title">Użyj starszego mechanizmu haszowania</string>
   <string name="use_legacy_hashing_summary">Wymuś użycie przedawnionego hashowania paczki dla zachowania kompatybilności</string>
-  <string name="restart_on_wakeup_title">Uruchom ponownie przy wybudzeniu</string>
-  <string name="restart_on_wakeup_summary">Domyślnie włączone. Wyłączenie tej funkcji może skutkować w opóźnieniu skanowaniu zmian i łączenia z urządzeniami celem oszczędzania baterii</string>
   <!--Dialog shown before config export-->
   <string name="dialog_confirm_export">Wyeksportować ustawienia? Istniejące pliki zostaną zastąpione.\n\nUWAGA! Inne programy mogą odczytać klucz prywatny z lokalizacji kopii zapasowej i użyć go by pobrać bądź zmodyfikować synchronizowane pliki.</string>
   <!--Dialog shown before config import-->

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -234,8 +234,6 @@ Por favor, nos avise sobre quaisquer problemas que você encontrar via Github.</
   <string name="toast_invalid_http_proxy_address">Entrada viola sintaxe do proxy \'http://[IP/HOSTNAME]:[PORT]\'</string>
   <string name="use_legacy_hashing_title">Usar hashing legado</string>
   <string name="use_legacy_hashing_summary">Forçar o Syncthing a usar hashing legado para fins de compatibilidade</string>
-  <string name="restart_on_wakeup_title">Reiniciar no Wakeup</string>
-  <string name="restart_on_wakeup_summary">Padrão: habilitado. Desabilitando esse recurso pode resultar em varreduras nos diretórios e reconexões com dispositivos sendo adiadas para poupar bateria.</string>
   <!--Dialog shown before config export-->
   <string name="dialog_confirm_export">Quer mesmo exportar a configuração? Arquivos existentes serão sobrescritos.\n\nAVISO! Outros aplicativos poderão ler a chave privada do arquivo de backup e usá-la para ler e escrever seus arquivos sincronizados.</string>
   <!--Dialog shown before config import-->

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -304,8 +304,6 @@ Reporte, através do Github, quaisquer problemas que encontre, por favor.</strin
   <string name="toast_invalid_http_proxy_address">O texto viola a sintaxe do proxy \'http://[IP/HOSTNAME]:[PORT]\'</string>
   <string name="use_legacy_hashing_title">Usar verificação antiga</string>
   <string name="use_legacy_hashing_summary">Forçar o Syncthing a usar um pacote de verificação antiga por questões de compatabilidade</string>
-  <string name="restart_on_wakeup_title">Reiniciar com o sinal para acordar</string>
-  <string name="restart_on_wakeup_summary">Predefinido: Activo. Desactivar esta funcionalidade pode resultar em atrasos nas pesquisas de pastas e nas ligações aos dispositivos, para poupar bateria.</string>
   <!--Dialog shown before config export-->
   <string name="dialog_confirm_export">Tem a certeza de que quer exportar a sua configuração? Ficheiros existentes serão sobrescritos.\n\nAVISO! Outras aplicações poderão ler a chave privada da localização da cópia de segurança e utilizá-la para descarregar/modificar os ficheiros sincronizados.</string>
   <!--Dialog shown before config import-->

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -304,8 +304,6 @@ Vă rugăm să raportați orice problemă întâlniți, prin intermediul GitHub.
   <string name="toast_invalid_http_proxy_address">Textul nu respectă sintaxa proxy \'http://[IP/HOSTNAME]:[PORT]\'</string>
   <string name="use_legacy_hashing_title">Folosește modul vechi de hashing</string>
   <string name="use_legacy_hashing_summary">Forțează utilizarea pachetului de hashing vechi din motive de compatibilitate</string>
-  <string name="restart_on_wakeup_title">Repornire la trezire</string>
-  <string name="restart_on_wakeup_summary">Implicit: Activat. Dezactivarea acestei caracteristici ar putea duce la amânarea scanării directoarelor și a conectării dispozitivelor pentru a putea micșora consumul bateriei.</string>
   <!--Dialog shown before config export-->
   <string name="dialog_confirm_export">Chiar doriți să exportați configurația? Fișierele existente vor fi suprascrise.\n\nATENȚIE! Alte aplicații vor putea să citească cheia privată din locația copiei de rezervă și să o folosească pentru a descărca/modifica fișierele sincronizate.</string>
   <!--Dialog shown before config import-->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -305,8 +305,6 @@
   <string name="toast_invalid_http_proxy_address">Проверьте синтаксис: \'http://[IP/HOSTNAME]:[PORT]\'</string>
   <string name="use_legacy_hashing_title">Использовать старый метод хеширования</string>
   <string name="use_legacy_hashing_summary">Принудительно использовать старый метод в целях совместимости</string>
-  <string name="restart_on_wakeup_title">Перезапуск при пробуждении</string>
-  <string name="restart_on_wakeup_summary">По умолчанию включено. Выключение этой функции может вызвать задержки при сканировании папок и переподключениях устройства для экономии заряда батареи.</string>
   <!--Dialog shown before config export-->
   <string name="dialog_confirm_export">Вы точно хотите экспортировать конфигурацию? Существующие файлы будут перезаписаны.\n\nВНИМАНИЕ! Другие приложения могут иметь возможность считать приватный ключ из резервной копии и использовать его, чтобы скачать или изменить синхронизируемые файлы.</string>
   <!--Dialog shown before config import-->

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -303,8 +303,6 @@ Rapportera eventuella problem du stöter på via Github.</string>
   <string name="toast_invalid_http_proxy_address">Inmatning bryter mot proxysyntaxen \'http://[IP/HOSTNAME]:[PORT]\'</string>
   <string name="use_legacy_hashing_title">Använd legacy hashing</string>
   <string name="use_legacy_hashing_summary">Tvinga Syncthing att använda legacy hashningspaket för kompatibilitetsändamål</string>
-  <string name="restart_on_wakeup_title">Starta om vid Vakna upp</string>
-  <string name="restart_on_wakeup_summary">Standard: Aktiverad. Om du inaktiverar den här funktionen kan det resultera i försenade mappuppdateringar och återkopplingar av enheter för att spara batteri.</string>
   <!--Dialog shown before config export-->
   <string name="dialog_confirm_export">Vill du verkligen exportera din konfiguration? Befintliga filer kommer att skrivas över.\n\nVARNING! Andra appar kan få möjlighet att läsa den privata nyckeln från säkerhetskopian och använda den för att hämta/ändra synkroniserade filer.</string>
   <!--Dialog shown before config import-->

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -303,8 +303,6 @@ Lütfen karşılaştığınız herhangi bir sorunu Github aracılığıyla bildi
   <string name="toast_invalid_http_proxy_address">Girdi, \'http://[IP/ANAMAKİNEADI]:[B.NOKTASI]\' proksi sözdizimini ihlal ediyor</string>
   <string name="use_legacy_hashing_title">Eski adresleme kullan</string>
   <string name="use_legacy_hashing_summary">Uyumluluk amacıyla eski adresleme paketini kullanmak için Syncthing\'i zorlayın</string>
-  <string name="restart_on_wakeup_title">Uyanmada yeniden başlat</string>
-  <string name="restart_on_wakeup_summary">Varsayılan: Etkinleştirildi. Bu özelliğin etkisizleştirilmesi, klasör taramalarına ve cihazın pilden tasarruf etmek için yeniden bağlanmasının gecikmesine neden olabilir.</string>
   <!--Dialog shown before config export-->
   <string name="dialog_confirm_export">Yeni yapılandırmayı gerçekten dışa aktarmak istiyor musunuz? Varolan dosyaların üzerine yazılacaktır.\n\nDİKKAT! Diğer uygulamalar gizli anahtarı yedekleme konumundan okuyabilir ve eşzamanlanan dosyaları indirmek/değiştirmek için kullanabilir.</string>
   <!--Dialog shown before config import-->

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -305,8 +305,6 @@
   <string name="toast_invalid_http_proxy_address">Введені дані не відповідають синтаксису проксі \'http://[IP/HOSTNAME]:[PORT]\'</string>
   <string name="use_legacy_hashing_title">Використовувати застарілий спосіб хешування</string>
   <string name="use_legacy_hashing_summary">Змусити Syncthing використовувати застарілий спосіб хешування з метою забезпечення сумісності</string>
-  <string name="restart_on_wakeup_title">Перезапустити при пробудженні</string>
-  <string name="restart_on_wakeup_summary">За-замовчуванням: Увімкнено. Вимкнення цієї функції може призвести до відкладення сканувань тек і перепідключень пристрою з метою збереження заряду батареї.</string>
   <!--Dialog shown before config export-->
   <string name="dialog_confirm_export">Ви справді хочете експортувати свої налаштування? Існуючі файли будуть перезаписані.\n\nУВАГА! Інші додатки можуть прочитати приватний ключ з файлу резервної копії і використати його для завантаження / зміни синхронізованих файлів.</string>
   <!--Dialog shown before config import-->

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -302,8 +302,6 @@ Vui lòng báo cáo những vấn đề bạn gặp qua Github.</string>
   <string name="toast_invalid_http_proxy_address">Đầu vào vi phạm cú pháp proxy \'http://[IP/TÊN MIỀN]:[CỔNG]\'</string>
   <string name="use_legacy_hashing_title">Sử dụng hash cũ</string>
   <string name="use_legacy_hashing_summary">Buộc Syncthing sử dụng gói hash cũ vì mục đích tương thích</string>
-  <string name="restart_on_wakeup_title">Khởi động lại khi thức dậy</string>
-  <string name="restart_on_wakeup_summary">Mặc định: Bật. Việc tắt tính năng này có thể dẫn đến việc quét thư mục và kết nối lại thiết bị bị trì hoãn để tiết kiệm pin.</string>
   <!--Dialog shown before config export-->
   <string name="dialog_confirm_export">Có chắc là bạn muốn xuất cấu hình? Các tập tin hiện thời sẽ bị ghi đè.\n\nCẢNH BÁO! Các ứng dụng khác có thể đọc được khoá riêng tư từ vị trí sao lưu và dùng nó để tải về/chỉnh sửa các tập tin đã đồng bộ.</string>
   <!--Dialog shown before config import-->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -304,8 +304,6 @@
   <string name="toast_invalid_http_proxy_address">请按照 “http://[IP/主机名]:[端口]” 的格式输入代理地址</string>
   <string name="use_legacy_hashing_title">使用传统哈希</string>
   <string name="use_legacy_hashing_summary">强制 syncthing 使用传统哈希包出于兼容目的</string>
-  <string name="restart_on_wakeup_title">唤醒时重启</string>
-  <string name="restart_on_wakeup_summary">默认：启用。禁用该设置可推迟目录扫描和设备连接来节省电量。</string>
   <!--Dialog shown before config export-->
   <string name="dialog_confirm_export">您确定要导出您的配置？若您之前导出过配置，则文件会被当前导出的配置所覆盖。\n\n 警告！其他应用程序可以从您导出的配置文件中获取到您的密钥，并且可以通过它来下载或者修改您的同步文件。</string>
   <!--Dialog shown before config import-->

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -245,7 +245,6 @@
   <!--Toast after entering invalid http proxy address-->
   <string name="use_legacy_hashing_title">使用過時的雜湊</string>
   <string name="use_legacy_hashing_summary">為了相容性，強制 Syncthing 使用過時的雜湊套</string>
-  <string name="restart_on_wakeup_title">喚醒時重新啟動</string>
   <!--Dialog shown before config export-->
   <string name="dialog_confirm_export">你確認要匯出你的設定？已存在的檔案將會被覆蓋。\n\n警告！其他的應用程式也許能從備份位置讀取私鑰，並且利用它來下載、修改同步的檔案。</string>
   <!--Dialog shown before config import-->

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -269,7 +269,6 @@
   <!--Toast after entering invalid http proxy address-->
   <string name="use_legacy_hashing_title">使用過時的雜湊</string>
   <string name="use_legacy_hashing_summary">為了相容性，強制 Syncthing 使用過時的雜湊套</string>
-  <string name="restart_on_wakeup_title">喚醒時重新啟動</string>
   <!--Dialog shown before config export-->
   <string name="dialog_confirm_export">你確認要匯出你的設定？已存在的檔案將會被覆蓋。\n\n警告！其他的應用程式也許能從備份位置讀取私鑰，並且利用它來下載、修改同步的檔案。</string>
   <!--Dialog shown before config import-->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -478,10 +478,6 @@ Please report any problems you encounter via Github.</string>
 
     <string name="use_legacy_hashing_summary">Force Syncthing to use legacy hashing package for compatibility purposes</string>
 
-    <string name="restart_on_wakeup_title">Restart on Wakeup</string>
-
-    <string name="restart_on_wakeup_summary">Default: Enabled. Disabling this feature may result in folder scans and device reconnects being delayed to save battery.</string>
-
     <!-- Dialog shown before config export -->
     <string name="dialog_confirm_export">Do you really want to export your configuration? Existing files will be overwritten.\n\nWARNING! Other applications may be able to read the private key from the backup location and use it to download/modify synchronized files.</string>
 

--- a/app/src/main/res/xml/app_settings.xml
+++ b/app/src/main/res/xml/app_settings.xml
@@ -167,12 +167,6 @@
             android:inputType="textNoSuggestions" />
 
         <CheckBoxPreference
-            android:key="restartOnWakeup"
-            android:title="@string/restart_on_wakeup_title"
-            android:summary="@string/restart_on_wakeup_summary"
-            android:defaultValue="false" />
-
-        <CheckBoxPreference
             android:key="urAccepted"
             android:title="@string/usage_reporting"
             android:persistent="false" />


### PR DESCRIPTION
The option "restartOnWakeup" was removed in Syncthing v1.21.0 [1]. Thus, remove it from the Android app as well, since the option does not perform any function anymore. In addition, update the Docs also [2].

[1] https://github.com/syncthing/syncthing/issues/8448
[2] https://github.com/syncthing/docs/pull/815