### PR TITLE
Set a custom build user

### DIFF
--- a/.github/workflows/build-app.yaml
+++ b/.github/workflows/build-app.yaml
@@ -9,7 +9,7 @@ on:
 
 env:
   # Our build metadata
-  BUILD_USER: builder
+  BUILD_USER: android-builder
   BUILD_HOST: github.syncthing.net
 
 jobs:

--- a/.github/workflows/image-builder-template.yaml
+++ b/.github/workflows/image-builder-template.yaml
@@ -9,7 +9,7 @@ on:
 
 env:
   # Our build metadata
-  BUILD_USER: builder
+  BUILD_USER: android-builder
   BUILD_HOST: github.syncthing.net
   # template var
   image: ghcr.io/syncthing/syncthing-android-builder

--- a/.github/workflows/release-app.yaml
+++ b/.github/workflows/release-app.yaml
@@ -11,7 +11,7 @@ on:
 
 env:
   # Our build metadata
-  BUILD_USER: builder
+  BUILD_USER: android-builder
   BUILD_HOST: github.syncthing.net
 
 jobs:


### PR DESCRIPTION
We need a dedicated build user to be able to distinguish the distribution channel. See https://github.com/syncthing/syncthing/issues/9140