### PR TITLE
Use StrictMode VmPolicy only in debug build type

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/SyncthingApp.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/SyncthingApp.java
@@ -25,6 +25,12 @@ public class SyncthingApp extends Application {
 
         new Languages(this).setLanguage(this);
 
+        if (BuildConfig.DEBUG) {
+            setStrictMode();
+        }
+    }
+
+    private void setStrictMode() {
         // Set VM policy to avoid crash when sending folder URI to file manager.
         StrictMode.VmPolicy policy = new StrictMode.VmPolicy.Builder()
                 .detectAll()


### PR DESCRIPTION
## Description 
`StrictMode` makes sense mainly in for debug build types, enabling it for release does not provide any value as it can add additional overhead and its logs going to be removed (because R8 strips them).





## Changes
* Enable the StrictMode VM policy only for debug build type