### PR TITLE
Remove outdated drawer entry for CPU usage.

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/fragments/DrawerFragment.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/fragments/DrawerFragment.java
@@ -43,7 +43,6 @@ public class DrawerFragment extends Fragment implements View.OnClickListener {
 
     private static final String TAG = "DrawerFragment";
 
-    private TextView mCpuUsage;
     private TextView mRamUsage;
     private TextView mDownload;
     private TextView mUpload;
@@ -99,7 +98,6 @@ public class DrawerFragment extends Fragment implements View.OnClickListener {
         mActivity = (MainActivity) getActivity();
         sharedPreferences = PreferenceManager.getDefaultSharedPreferences(mActivity);
 
-        mCpuUsage       = view.findViewById(R.id.cpu_usage);
         mRamUsage       = view.findViewById(R.id.ram_usage);
         mDownload       = view.findViewById(R.id.download);
         mUpload         = view.findViewById(R.id.upload);
@@ -178,7 +176,6 @@ public class DrawerFragment extends Fragment implements View.OnClickListener {
             return;
         NumberFormat percentFormat = NumberFormat.getPercentInstance();
         percentFormat.setMaximumFractionDigits(2);
-        mCpuUsage.setText(percentFormat.format(info.cpuPercent / 100));
         mRamUsage.setText(Util.readableFileSize(mActivity, info.sys));
         int announceTotal = info.discoveryMethods;
         int announceConnected =

--- a/app/src/main/res/layout/fragment_drawer.xml
+++ b/app/src/main/res/layout/fragment_drawer.xml
@@ -73,29 +73,6 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="@string/cpu_usage"
-                    android:textAppearance="@style/TextAppearance.AppCompat.Body1"
-                    android:textColor="?android:textColorSecondary" />
-
-                <TextView
-                    android:id="@+id/cpu_usage"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:textAppearance="@style/TextAppearance.AppCompat.Caption" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:gravity="center_vertical"
-                android:minHeight="48dp"
-                android:orientation="vertical"
-                android:paddingLeft="@dimen/abc_action_bar_content_inset_material"
-                android:paddingRight="@dimen/abc_action_bar_content_inset_material">
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
                     android:text="@string/ram_usage"
                     android:textAppearance="@style/TextAppearance.AppCompat.Body1"
                     android:textColor="?android:textColorSecondary" />

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -105,8 +105,6 @@
     <string name="download_title_colon">"Изтегляне: "</string>
     <!--Same as upload_title with a colon and space appended-->
     <string name="upload_title_colon">"Качване: "</string>
-    <!--Title for current CPU usage-->
-    <string name="cpu_usage">Използване на CPU</string>
     <!--Title for current RAM usage-->
     <string name="ram_usage">Използване на RAM</string>
     <!--Title for announce server status-->

--- a/app/src/main/res/values-ca-rES/strings.xml
+++ b/app/src/main/res/values-ca-rES/strings.xml
@@ -105,8 +105,6 @@
     <string name="download_title_colon">"Descàrrega: "</string>
     <!--Same as upload_title with a colon and space appended-->
     <string name="upload_title_colon">"Pujada: "</string>
-    <!--Title for current CPU usage-->
-    <string name="cpu_usage">Ús de CPU</string>
     <!--Title for current RAM usage-->
     <string name="ram_usage">Ús de RAM</string>
     <!--Title for announce server status-->

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -107,8 +107,6 @@
     <string name="download_title_colon">"Rychlost stahování: "</string>
     <!--Same as upload_title with a colon and space appended-->
     <string name="upload_title_colon">"Rychlost odesílání: "</string>
-    <!--Title for current CPU usage-->
-    <string name="cpu_usage">Využití CPU</string>
     <!--Title for current RAM usage-->
     <string name="ram_usage">Využití RAM</string>
     <!--Title for announce server status-->

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -105,8 +105,6 @@
     <string name="download_title_colon">"Download: "</string>
     <!--Same as upload_title with a colon and space appended-->
     <string name="upload_title_colon">"Upload: "</string>
-    <!--Title for current CPU usage-->
-    <string name="cpu_usage">CPU forbrug</string>
     <!--Title for current RAM usage-->
     <string name="ram_usage">RAM forbrug</string>
     <!--Title for announce server status-->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -103,8 +103,6 @@
     <string name="download_title_colon">"Herunterladen: "</string>
     <!--Same as upload_title with a colon and space appended-->
     <string name="upload_title_colon">"Hochladen: "</string>
-    <!--Title for current CPU usage-->
-    <string name="cpu_usage">Prozessorauslastung</string>
     <!--Title for current RAM usage-->
     <string name="ram_usage">RAM-Auslastung</string>
     <!--Title for announce server status-->

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -80,8 +80,6 @@
     <string name="download_title_colon">"Λήψη: "</string>
     <!--Same as upload_title with a colon and space appended-->
     <string name="upload_title_colon">"Αποστολή: "</string>
-    <!--Title for current CPU usage-->
-    <string name="cpu_usage">Χρήση CPU</string>
     <!--Title for current RAM usage-->
     <string name="ram_usage">Χρήση RAM</string>
     <!--Title for announce server status-->

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -84,8 +84,6 @@
     <string name="download_title_colon">"Descarga: "</string>
     <!--Same as upload_title with a colon and space appended-->
     <string name="upload_title_colon">"Subida: "</string>
-    <!--Title for current CPU usage-->
-    <string name="cpu_usage">Uso de CPU</string>
     <!--Title for current RAM usage-->
     <string name="ram_usage">Uso de RAM</string>
     <!--Title for announce server status-->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -106,8 +106,6 @@
     <string name="download_title_colon">"Descarga: "</string>
     <!--Same as upload_title with a colon and space appended-->
     <string name="upload_title_colon">"Subida: "</string>
-    <!--Title for current CPU usage-->
-    <string name="cpu_usage">Uso de CPU</string>
     <!--Title for current RAM usage-->
     <string name="ram_usage">Uso de RAM</string>
     <!--Title for announce server status-->

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -112,8 +112,6 @@
     <string name="download_title_colon">"Deskarga: "</string>
     <!--Same as upload_title with a colon and space appended-->
     <string name="upload_title_colon">"Igo: "</string>
-    <!--Title for current CPU usage-->
-    <string name="cpu_usage">CPU Erabilera</string>
     <!--Title for current RAM usage-->
     <string name="ram_usage">RAM erabilera</string>
     <!--Title for announce server status-->

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -84,8 +84,6 @@
     <string name="download_title_colon">"Lataus: "</string>
     <!--Same as upload_title with a colon and space appended-->
     <string name="upload_title_colon">"Lähetys: "</string>
-    <!--Title for current CPU usage-->
-    <string name="cpu_usage">Suorittimen käyttö</string>
     <!--Title for current RAM usage-->
     <string name="ram_usage">Muistin käyttö</string>
     <!--Title for announce server status-->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -106,8 +106,6 @@
     <string name="download_title_colon">"Réception: "</string>
     <!--Same as upload_title with a colon and space appended-->
     <string name="upload_title_colon">"Émission: "</string>
-    <!--Title for current CPU usage-->
-    <string name="cpu_usage">Utilisation du CPU</string>
     <!--Title for current RAM usage-->
     <string name="ram_usage">Utilisation de la RAM</string>
     <!--Title for announce server status-->

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -105,8 +105,6 @@
     <string name="download_title_colon">"Letöltve: "</string>
     <!--Same as upload_title with a colon and space appended-->
     <string name="upload_title_colon">"Feltöltve: "</string>
-    <!--Title for current CPU usage-->
-    <string name="cpu_usage">CPU használat</string>
     <!--Title for current RAM usage-->
     <string name="ram_usage">Memória használat</string>
     <!--Title for announce server status-->

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -87,8 +87,6 @@
     <string name="download_title_colon">"Unduhan: "</string>
     <!--Same as upload_title with a colon and space appended-->
     <string name="upload_title_colon">"Unggah: "</string>
-    <!--Title for current CPU usage-->
-    <string name="cpu_usage">Penggunaan CPU</string>
     <!--Title for current RAM usage-->
     <string name="ram_usage">Penggunaan RAM</string>
     <!--Title for announce server status-->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -106,8 +106,6 @@
     <string name="download_title_colon">"Download: "</string>
     <!--Same as upload_title with a colon and space appended-->
     <string name="upload_title_colon">"Upload: "</string>
-    <!--Title for current CPU usage-->
-    <string name="cpu_usage">Utilizzo CPU</string>
     <!--Title for current RAM usage-->
     <string name="ram_usage">Utilizzo RAM</string>
     <!--Title for announce server status-->

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -100,8 +100,6 @@
     <string name="download_title_colon">"ダウンロード: "</string>
     <!--Same as upload_title with a colon and space appended-->
     <string name="upload_title_colon">"アップロード: "</string>
-    <!--Title for current CPU usage-->
-    <string name="cpu_usage">CPU 使用率</string>
     <!--Title for current RAM usage-->
     <string name="ram_usage">メモリ使用量</string>
     <!--Title for announce server status-->

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -100,8 +100,6 @@
     <string name="download_title_colon">"수신: "</string>
     <!--Same as upload_title with a colon and space appended-->
     <string name="upload_title_colon">"송신: "</string>
-    <!--Title for current CPU usage-->
-    <string name="cpu_usage">CPU 사용량</string>
     <!--Title for current RAM usage-->
     <string name="ram_usage">RAM 사용량</string>
     <!--Title for announce server status-->

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -62,8 +62,6 @@
     <string name="download_title_colon">"Nedlasting: "</string>
     <!--Same as upload_title with a colon and space appended-->
     <string name="upload_title_colon">"Opplasting: "</string>
-    <!--Title for current CPU usage-->
-    <string name="cpu_usage">CPU-forbruk</string>
     <!--Title for current RAM usage-->
     <string name="ram_usage">RAM-forbruk</string>
     <!--Title for announce server status-->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -105,8 +105,6 @@
     <string name="download_title_colon">"Download: "</string>
     <!--Same as upload_title with a colon and space appended-->
     <string name="upload_title_colon">"Upload: "</string>
-    <!--Title for current CPU usage-->
-    <string name="cpu_usage">CPU-gebruik</string>
     <!--Title for current RAM usage-->
     <string name="ram_usage">RAM-gebruik</string>
     <!--Title for announce server status-->

--- a/app/src/main/res/values-nn/strings.xml
+++ b/app/src/main/res/values-nn/strings.xml
@@ -81,8 +81,6 @@
     <string name="download_title_colon">"Nedlasting: "</string>
     <!--Same as upload_title with a colon and space appended-->
     <string name="upload_title_colon">"Opplasting: "</string>
-    <!--Title for current CPU usage-->
-    <string name="cpu_usage">Prosessorbruk</string>
     <!--Title for current RAM usage-->
     <string name="ram_usage">Minnebruk</string>
     <!--Title for announce server status-->

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -114,8 +114,6 @@
     <string name="download_title_colon">"Pobieranie: "</string>
     <!--Same as upload_title with a colon and space appended-->
     <string name="upload_title_colon">"Wysyłanie: "</string>
-    <!--Title for current CPU usage-->
-    <string name="cpu_usage">Użycie procesora</string>
     <!--Title for current RAM usage-->
     <string name="ram_usage">Użycie pamięci RAM</string>
     <!--Title for announce server status-->

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -106,8 +106,6 @@
     <string name="download_title_colon">"Recepção: "</string>
     <!--Same as upload_title with a colon and space appended-->
     <string name="upload_title_colon">"Envio: "</string>
-    <!--Title for current CPU usage-->
-    <string name="cpu_usage">Uso de CPU</string>
     <!--Title for current RAM usage-->
     <string name="ram_usage">Uso de RAM</string>
     <!--Title for announce server status-->

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -106,8 +106,6 @@
     <string name="download_title_colon">"Recepção: "</string>
     <!--Same as upload_title with a colon and space appended-->
     <string name="upload_title_colon">"Envio: "</string>
-    <!--Title for current CPU usage-->
-    <string name="cpu_usage">Utilização da CPU</string>
     <!--Title for current RAM usage-->
     <string name="ram_usage">Utilização da RAM</string>
     <!--Title for announce server status-->

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -113,8 +113,6 @@
     <string name="download_title_colon">"Descărcare: "</string>
     <!--Same as upload_title with a colon and space appended-->
     <string name="upload_title_colon">"Încărcare: "</string>
-    <!--Title for current CPU usage-->
-    <string name="cpu_usage">Utilizare CPU</string>
     <!--Title for current RAM usage-->
     <string name="ram_usage">Utilizare RAM</string>
     <!--Title for announce server status-->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -107,8 +107,6 @@
     <string name="download_title_colon">"Скачивание: "</string>
     <!--Same as upload_title with a colon and space appended-->
     <string name="upload_title_colon">"Отдача: "</string>
-    <!--Title for current CPU usage-->
-    <string name="cpu_usage">Использование ЦП</string>
     <!--Title for current RAM usage-->
     <string name="ram_usage">Использование ОЗУ</string>
     <!--Title for announce server status-->

--- a/app/src/main/res/values-si/strings.xml
+++ b/app/src/main/res/values-si/strings.xml
@@ -70,8 +70,6 @@
     <!--DrawerFragment-->
     <!--Same as download_title with a colon and space appended-->
     <!--Same as upload_title with a colon and space appended-->
-    <!--Title for current CPU usage-->
-    <string name="cpu_usage">CPU භාවිතය</string>
     <!--Title for current RAM usage-->
     <string name="ram_usage">RAM භාවිතය</string>
     <!--Title for announce server status-->

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -107,8 +107,6 @@
     <string name="download_title_colon">"Sťahovanie: "</string>
     <!--Same as upload_title with a colon and space appended-->
     <string name="upload_title_colon">"Odosielanie: "</string>
-    <!--Title for current CPU usage-->
-    <string name="cpu_usage">Vyťaženie procesora</string>
     <!--Title for current RAM usage-->
     <string name="ram_usage">Využitie RAM</string>
     <!--Title for announce server status-->

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -105,8 +105,6 @@
     <string name="download_title_colon">"Tar emot: "</string>
     <!--Same as upload_title with a colon and space appended-->
     <string name="upload_title_colon">"Skickar: "</string>
-    <!--Title for current CPU usage-->
-    <string name="cpu_usage">CPU användning</string>
     <!--Title for current RAM usage-->
     <string name="ram_usage">RAM användning</string>
     <!--Title for announce server status-->

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -112,8 +112,6 @@
     <string name="download_title_colon">"İndirme: "</string>
     <!--Same as upload_title with a colon and space appended-->
     <string name="upload_title_colon">"Gönderme: "</string>
-    <!--Title for current CPU usage-->
-    <string name="cpu_usage">İşlemci Kullanımı</string>
     <!--Title for current RAM usage-->
     <string name="ram_usage">Bellek Kullanımı</string>
     <!--Title for announce server status-->

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -107,8 +107,6 @@
     <string name="download_title_colon">"Завантаження: "</string>
     <!--Same as upload_title with a colon and space appended-->
     <string name="upload_title_colon">"Вивантаження: "</string>
-    <!--Title for current CPU usage-->
-    <string name="cpu_usage">Використання ЦП</string>
     <!--Title for current RAM usage-->
     <string name="ram_usage">Використання ОЗП</string>
     <!--Title for announce server status-->

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -104,8 +104,6 @@
     <string name="download_title_colon">"Tải xuống: "</string>
     <!--Same as upload_title with a colon and space appended-->
     <string name="upload_title_colon">"Tải lên: "</string>
-    <!--Title for current CPU usage-->
-    <string name="cpu_usage">Mức s.dụng CPU</string>
     <!--Title for current RAM usage-->
     <string name="ram_usage">Mức s.dụng RAM</string>
     <!--Title for announce server status-->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -104,8 +104,6 @@
     <string name="download_title_colon">"下载： "</string>
     <!--Same as upload_title with a colon and space appended-->
     <string name="upload_title_colon">"上传： "</string>
-    <!--Title for current CPU usage-->
-    <string name="cpu_usage">CPU 使用率</string>
     <!--Title for current RAM usage-->
     <string name="ram_usage">内存使用</string>
     <!--Title for announce server status-->

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -104,8 +104,6 @@
     <string name="download_title_colon">"下載: "</string>
     <!--Same as upload_title with a colon and space appended-->
     <string name="upload_title_colon">"上載: "</string>
-    <!--Title for current CPU usage-->
-    <string name="cpu_usage">CPU 使用率</string>
     <!--Title for current RAM usage-->
     <string name="ram_usage">記憶體使用率</string>
     <!--Title for announce server status-->

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -104,8 +104,6 @@
     <string name="download_title_colon">"下載: "</string>
     <!--Same as upload_title with a colon and space appended-->
     <string name="upload_title_colon">"上傳: "</string>
-    <!--Title for current CPU usage-->
-    <string name="cpu_usage">CPU 使用率</string>
     <!--Title for current RAM usage-->
     <string name="ram_usage">記憶體使用率</string>
     <!--Title for announce server status-->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -171,9 +171,6 @@
     <!-- Same as upload_title with a colon and space appended -->
     <string name="upload_title_colon">Upload:\u0020</string>
 
-    <!-- Title for current CPU usage -->
-    <string name="cpu_usage">CPU Usage</string>
-
     <!-- Title for current RAM usage -->
     <string name="ram_usage">RAM Usage</string>
 


### PR DESCRIPTION
The code to calculate this metric has long been removed from the backend upstream, in commit https://github.com/syncthing/syncthing/commit/c7d6a6d78042876d9a27b13df2ae45783dca7c37.

Thus the GUI element should go away as well, currently always displaying 0 percent anyways.

Ref https://github.com/syncthing/syncthing/pull/6393