### PR TITLE
Upgrade Gradle wrapper to version `8.5`

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.configurationcache.extensions.capitalized
+
 plugins {
     id("com.android.application")
     id("com.github.ben-manes.versions")
@@ -107,4 +109,12 @@ tasks.register<Delete>("deleteUnsupportedPlayTranslations") {
         "src/main/play/listings/nn/",
         "src/main/play/listings/ta/",
     )
+}
+
+project.afterEvaluate {
+    android.buildTypes.forEach {
+        tasks.named("merge${it.name.capitalized()}JniLibFolders") {
+            dependsOn(":syncthing:buildNative")
+        }
+    }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Mon Oct 05 14:20:28 EEST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip


### PR DESCRIPTION
## Description
Dependabot does not support (yet) upgrading the Gradle wrapper thus it needs to be updated/upgraded manually.

## Changes:
* Upgrade gradle wrapper to version `8.5`

See also: https://github.com/dependabot/dependabot-core/issues/2223