### PR TITLE
Remove code in outdated version checks

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderPickerActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderPickerActivity.java
@@ -104,7 +104,7 @@ public class FolderPickerActivity extends SyncthingActivity
         }
 
         Boolean prefUseRoot = PreferenceManager.getDefaultSharedPreferences(this).getBoolean(Constants.PREF_USE_ROOT, false);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT && !prefUseRoot) {
+        if (!prefUseRoot) {
             Toast.makeText(this, R.string.kitkat_external_storage_warning, Toast.LENGTH_LONG)
                     .show();
         }
@@ -118,10 +118,8 @@ public class FolderPickerActivity extends SyncthingActivity
     @SuppressLint("NewApi")
     private void populateRoots() {
         ArrayList<File> roots = new ArrayList<>();
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-            roots.addAll(Arrays.asList(getExternalFilesDirs(null)));
-            roots.remove(getExternalFilesDir(null));
-        }
+        roots.addAll(Arrays.asList(getExternalFilesDirs(null)));
+        roots.remove(getExternalFilesDir(null));
 
         String rootDir = getIntent().getStringExtra(EXTRA_ROOT_DIRECTORY);
         if (getIntent().hasExtra(EXTRA_ROOT_DIRECTORY) && !TextUtils.isEmpty(rootDir)) {
@@ -132,9 +130,7 @@ public class FolderPickerActivity extends SyncthingActivity
             roots.add(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES));
             roots.add(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS));
             roots.add(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DCIM));
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                roots.add(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS));
-            }
+            roots.add(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS));
 
             // Add paths that might not be accessible to Syncthing.
             SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(this);

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/WebGuiActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/WebGuiActivity.java
@@ -77,13 +77,6 @@ public class WebGuiActivity extends StateDialogActivity
         @Override
         public void onReceivedSslError(WebView view, SslErrorHandler handler, SslError error) {
             try {
-                int sdk = android.os.Build.VERSION.SDK_INT;
-                if (sdk < Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
-                    // The mX509Certificate field is not available for ICS- devices
-                    Log.w(TAG, "Skipping certificate check for devices <ICS");
-                    handler.proceed();
-                    return;
-                }
                 // Use reflection to access the private mX509Certificate field of SslCertificate
                 SslCertificate sslCert = error.getCertificate();
                 Field f = sslCert.getClass().getDeclaredField("mX509Certificate");
@@ -252,11 +245,6 @@ public class WebGuiActivity extends StateDialogActivity
      */
     @SuppressLint("PrivateApi")
     public static boolean setWebViewProxy(Context appContext, String host, int port, String exclusionList) {
-        if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT) {
-            // Not supported on android version lower than KitKat.
-            return false;
-        }
-
         Properties properties = System.getProperties();
         properties.setProperty("http.proxyHost", host);
         properties.setProperty("http.proxyPort", Integer.toString(port));
@@ -282,11 +270,7 @@ public class WebGuiActivity extends StateDialogActivity
                         Intent intent = new Intent(Proxy.PROXY_CHANGE_ACTION);
 
                         String CLASS_NAME;
-                        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
-                            CLASS_NAME = "android.net.ProxyProperties";
-                        } else {
-                            CLASS_NAME = "android.net.ProxyInfo";
-                        }
+                        CLASS_NAME = "android.net.ProxyInfo";
                         Class cls = Class.forName(CLASS_NAME);
                         Constructor constructor = cls.getConstructor(String.class, Integer.TYPE, String.class);
                         constructor.setAccessible(true);

--- a/app/src/main/java/com/nutomic/syncthingandroid/fragments/DrawerFragment.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/fragments/DrawerFragment.java
@@ -284,10 +284,6 @@ public class DrawerFragment extends Fragment implements View.OnClickListener {
         }
         Log.i(TAG, "Exiting app on user request");
         mActivity.stopService(new Intent(mActivity, SyncthingService.class));
-        if(android.os.Build.VERSION.SDK_INT >= 21) {
-            mActivity.finishAndRemoveTask();
-        } else {
-            mActivity.finish();
-        }
+        mActivity.finishAndRemoveTask();
     }
 }

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/Util.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/Util.java
@@ -218,7 +218,7 @@ public class Util {
         if (activity.isFinishing())
             return;
 
-        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.JELLY_BEAN && activity.isDestroyed())
+        if (activity.isDestroyed())
             return;
 
         dialog.dismiss();


### PR DESCRIPTION
Refactor code inside `if-else` blocks that checks for versions that are no longer relevant. 
Few lines could be deleted some others were just un-wrapped from the if-else blocks.
The `if-else` blocks inside `PRNGFixes` file were left out as this file is should be deleted in https://github.com/syncthing/syncthing-android/pull/2036