### PR TITLE
Fix incorrect initialization of Info notification channel

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/service/NotificationHandler.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/NotificationHandler.java
@@ -73,9 +73,9 @@ public class NotificationHandler {
             mInfoChannel = new NotificationChannel(
                     CHANNEL_INFO, mContext.getString(R.string.notifications_other_channel),
                     NotificationManager.IMPORTANCE_LOW);
-            mPersistentChannel.enableVibration(false);
-            mPersistentChannel.setSound(null, null);
-            mPersistentChannel.setShowBadge(true);
+            mInfoChannel.enableVibration(false);
+            mInfoChannel.setSound(null, null);
+            mInfoChannel.setShowBadge(true);
             mNotificationManager.createNotificationChannel(mInfoChannel);
         } else {
             mPersistentChannel = null;


### PR DESCRIPTION
I was using syncthing as a reference for handling notifications in my app, when I noticed that the "Info" channel appears to be incorrectly initialized.

It looks like it was intended for the Info channel not to vibrate, not to make sound, but only to show a badge. This might be redundant as it's possible every notification pushed to this channel already follows those standards, I am unsure. However, the code used to initialize the Info channel was actually modifying the already created Persistent channel, and thus did nothing. 

This pull request fixes, what I think are typos which originated from a copy and paste of the code used to create the Persistent channel.

I think these lines should either be changed as per this pull request, or removed entirely.