### PR TITLE
Use the throwable overload to log api request errors

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/http/ApiRequest.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/http/ApiRequest.java
@@ -101,7 +101,7 @@ public abstract class ApiRequest {
             if (errorListener != null) {
                 errorListener.onError(error);
             } else {
-                Log.w(TAG, "Request to " + uri + " failed, " + error.getMessage());
+                Log.w(TAG, "Request to " + uri + " failed", error);
             }
         }) {
             @Override


### PR DESCRIPTION
Logs in 2029 show handshake errors - maybe this includes more context than just that message.