### PR TITLE
Update Android NDK llvm toolchains directory name

### DIFF
--- a/syncthing/build-syncthing.py
+++ b/syncthing/build-syncthing.py
@@ -9,7 +9,7 @@ import sys
 PLATFORM_DIRS = {
     'Windows': 'windows-x86_64',
     'Linux': 'linux-x86_64',
-    'Darwin': 'darwin-x86-64',
+    'Darwin': 'darwin-x86_64',
 }
 
 # The values here must correspond with those in ../docker/prebuild.sh


### PR DESCRIPTION
The current setup uses:
```
PLATFORM_DIRS = {
    'Windows': 'windows-x86_64',
    'Linux': 'linux-x86_64',
    'Darwin': 'darwin-x86-64',
}
```
I think the Darwin config has been configured like this by mistake.
Trying to build the app fails because `nativeBuild` task fail because it cannot locate the toolchain. 
Maybe in the past `darwin-x86-64` worked but I see the toolchains under `x86_64` directory now. 
And with `x86_64` the build works of course 😄 .


