### PR TITLE
Upgrade compile sdk and tools

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -31,8 +31,8 @@ dependencies {
 android {
     val ndkVersionShared = rootProject.extra.get("ndkVersionShared")
     // Changes to these values need to be reflected in `../docker/Dockerfile`
-    compileSdk = 33
-    buildToolsVersion = "33.0.2"
+    compileSdk = 34
+    buildToolsVersion = "34.0.0"
     ndkVersion = "${ndkVersionShared}"
 
     buildFeatures {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,7 @@ RUN yes | $SDKMANAGER --licenses > /dev/null
 ENV NDK_VERSION 25.2.9519653
 
 # Install other android packages, including NDK
-RUN $SDKMANAGER tools platform-tools "build-tools;33.0.2" "platforms;android-33" "extras;android;m2repository" "ndk;${NDK_VERSION}"
+RUN $SDKMANAGER tools platform-tools "build-tools;34.0.0" "platforms;android-34" "extras;android;m2repository" "ndk;${NDK_VERSION}"
 
 # Accept licenses of newly installed packages
 RUN yes | $SDKMANAGER --licenses


### PR DESCRIPTION
Upgrade compile sdk and tools from 33 to 34

This is needed to update Android Gradle Plugin (AGP) and other dependencies.