### PR TITLE
Update providing of SharedPreferences

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/SyncthingApp.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/SyncthingApp.java
@@ -4,6 +4,9 @@ import android.app.Application;
 import android.os.StrictMode;
 
 import com.google.android.material.color.DynamicColors;
+import com.nutomic.syncthingandroid.di.DaggerComponent;
+import com.nutomic.syncthingandroid.di.DaggerDaggerComponent;
+import com.nutomic.syncthingandroid.di.SyncthingModule;
 import com.nutomic.syncthingandroid.util.Languages;
 
 import javax.inject.Inject;

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FirstStartActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FirstStartActivity.java
@@ -38,6 +38,7 @@ import com.google.android.material.color.MaterialColors;
 import com.nutomic.syncthingandroid.R;
 import com.nutomic.syncthingandroid.SyncthingApp;
 import com.nutomic.syncthingandroid.databinding.ActivityFirstStartBinding;
+import com.nutomic.syncthingandroid.di.DefaultSharedPreferences;
 import com.nutomic.syncthingandroid.service.Constants;
 import com.nutomic.syncthingandroid.util.PermissionUtil;
 import com.nutomic.syncthingandroid.util.Util;
@@ -75,6 +76,7 @@ public class FirstStartActivity extends Activity {
     private ActivityFirstStartBinding binding;
 
     @Inject
+    @DefaultSharedPreferences
     SharedPreferences mPreferences;
 
     @SuppressLint("ClickableViewAccessibility")

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/MainActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/MainActivity.java
@@ -49,6 +49,7 @@ import android.widget.Toast;
 import com.annimon.stream.function.Consumer;
 import com.nutomic.syncthingandroid.R;
 import com.nutomic.syncthingandroid.SyncthingApp;
+import com.nutomic.syncthingandroid.di.DefaultSharedPreferences;
 import com.nutomic.syncthingandroid.fragments.DeviceListFragment;
 import com.nutomic.syncthingandroid.fragments.DrawerFragment;
 import com.nutomic.syncthingandroid.fragments.FolderListFragment;
@@ -102,7 +103,10 @@ public class MainActivity extends StateDialogActivity
 
     private ActionBarDrawerToggle mDrawerToggle;
     private DrawerLayout          mDrawerLayout;
-    @Inject SharedPreferences mPreferences;
+
+    @Inject
+    @DefaultSharedPreferences
+    SharedPreferences mPreferences;
 
     /**
      * Handles various dialogs based on current state.

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -27,6 +27,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
 import com.nutomic.syncthingandroid.R;
 import com.nutomic.syncthingandroid.SyncthingApp;
+import com.nutomic.syncthingandroid.di.DefaultSharedPreferences;
 import com.nutomic.syncthingandroid.model.Config;
 import com.nutomic.syncthingandroid.model.Device;
 import com.nutomic.syncthingandroid.model.Options;
@@ -103,7 +104,10 @@ public class SettingsActivity extends SyncthingActivity {
         private static final String KEY_ST_RESET_DELTAS = "st_reset_deltas";
 
         @Inject NotificationHandler mNotificationHandler;
-        @Inject SharedPreferences mPreferences;
+
+        @Inject
+        @DefaultSharedPreferences
+        SharedPreferences mPreferences;
 
         private PreferenceGroup    mCategoryRunConditions;
         private CheckBoxPreference mRunConditions;

--- a/app/src/main/java/com/nutomic/syncthingandroid/di/DaggerComponent.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/di/DaggerComponent.java
@@ -1,5 +1,6 @@
-package com.nutomic.syncthingandroid;
+package com.nutomic.syncthingandroid.di;
 
+import com.nutomic.syncthingandroid.SyncthingApp;
 import com.nutomic.syncthingandroid.activities.FirstStartActivity;
 import com.nutomic.syncthingandroid.activities.FolderPickerActivity;
 import com.nutomic.syncthingandroid.activities.MainActivity;

--- a/app/src/main/java/com/nutomic/syncthingandroid/di/DefaultSharedPreferences.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/di/DefaultSharedPreferences.java
@@ -1,0 +1,13 @@
+package com.nutomic.syncthingandroid.di;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+
+import javax.inject.Qualifier;
+
+@Qualifier
+@Retention(RUNTIME)
+public @interface DefaultSharedPreferences {
+
+}

--- a/app/src/main/java/com/nutomic/syncthingandroid/di/SyncthingModule.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/di/SyncthingModule.java
@@ -22,6 +22,7 @@ public class SyncthingModule {
 
     @Provides
     @Singleton
+    @DefaultSharedPreferences
     public SharedPreferences getPreferences() {
         return PreferenceManager.getDefaultSharedPreferences(mApp);
     }

--- a/app/src/main/java/com/nutomic/syncthingandroid/di/SyncthingModule.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/di/SyncthingModule.java
@@ -1,8 +1,9 @@
-package com.nutomic.syncthingandroid;
+package com.nutomic.syncthingandroid.di;
 
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 
+import com.nutomic.syncthingandroid.SyncthingApp;
 import com.nutomic.syncthingandroid.service.NotificationHandler;
 
 import javax.inject.Singleton;

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/EventProcessor.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/EventProcessor.java
@@ -21,6 +21,7 @@ import com.nutomic.syncthingandroid.R;
 import com.nutomic.syncthingandroid.SyncthingApp;
 import com.nutomic.syncthingandroid.activities.DeviceActivity;
 import com.nutomic.syncthingandroid.activities.FolderActivity;
+import com.nutomic.syncthingandroid.di.DefaultSharedPreferences;
 import com.nutomic.syncthingandroid.model.CompletionInfo;
 import com.nutomic.syncthingandroid.model.Device;
 import com.nutomic.syncthingandroid.model.Event;
@@ -60,8 +61,11 @@ public class EventProcessor implements  Runnable, RestApi.OnReceiveEventListener
 
     private final Context mContext;
     private final RestApi mApi;
-    @Inject SharedPreferences mPreferences;
     @Inject NotificationHandler mNotificationHandler;
+
+    @Inject
+    @DefaultSharedPreferences
+    SharedPreferences mPreferences;
 
     public EventProcessor(Context context, RestApi api) {
         ((SyncthingApp) context.getApplicationContext()).component().inject(this);

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/NotificationHandler.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/NotificationHandler.java
@@ -18,6 +18,7 @@ import com.nutomic.syncthingandroid.SyncthingApp;
 import com.nutomic.syncthingandroid.activities.FirstStartActivity;
 import com.nutomic.syncthingandroid.activities.LogActivity;
 import com.nutomic.syncthingandroid.activities.MainActivity;
+import com.nutomic.syncthingandroid.di.DefaultSharedPreferences;
 import com.nutomic.syncthingandroid.service.Constants;
 import com.nutomic.syncthingandroid.service.SyncthingService.State;
 
@@ -37,7 +38,6 @@ public class NotificationHandler {
     private static final String CHANNEL_PERSISTENT_WAITING = "03_syncthing_persistent_waiting";
 
     private final Context mContext;
-    @Inject SharedPreferences mPreferences;
     private final NotificationManager mNotificationManager;
     private final NotificationChannel mPersistentChannel;
     private final NotificationChannel mPersistentChannelWaiting;
@@ -45,6 +45,10 @@ public class NotificationHandler {
 
     private Boolean lastStartForegroundService = false;
     private Boolean appShutdownInProgress = false;
+
+    @Inject
+    @DefaultSharedPreferences
+    SharedPreferences mPreferences;
 
     public NotificationHandler(Context context) {
         ((SyncthingApp) context.getApplicationContext()).component().inject(this);

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/RunConditionMonitor.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/RunConditionMonitor.java
@@ -20,6 +20,7 @@ import androidx.annotation.Nullable;
 import android.util.Log;
 
 import com.nutomic.syncthingandroid.SyncthingApp;
+import com.nutomic.syncthingandroid.di.DefaultSharedPreferences;
 import com.nutomic.syncthingandroid.model.RunConditionCheckResult;
 
 import java.util.ArrayList;
@@ -59,8 +60,11 @@ public class RunConditionMonitor {
     }
 
     private final Context mContext;
-    @Inject SharedPreferences mPreferences;
     private ReceiverManager mReceiverManager;
+
+    @Inject
+    @DefaultSharedPreferences
+    SharedPreferences mPreferences;
 
     /**
      * Sending callback notifications through {@link OnRunConditionChangedListener} is enabled if not null.

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
@@ -14,6 +14,7 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import com.nutomic.syncthingandroid.R;
 import com.nutomic.syncthingandroid.SyncthingApp;
+import com.nutomic.syncthingandroid.di.DefaultSharedPreferences;
 import com.nutomic.syncthingandroid.service.Constants;
 import com.nutomic.syncthingandroid.util.Util;
 
@@ -56,9 +57,12 @@ public class SyncthingRunnable implements Runnable {
     private final File mSyncthingBinary;
     private String[] mCommand;
     private final File mLogFile;
-    @Inject SharedPreferences mPreferences;
     private final boolean mUseRoot;
     @Inject NotificationHandler mNotificationHandler;
+
+    @Inject
+    @DefaultSharedPreferences
+    SharedPreferences mPreferences;
 
     public enum Command {
         deviceid,           // Output the device ID to the command line.

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
@@ -12,6 +12,7 @@ import androidx.annotation.Nullable;
 import com.google.common.io.Files;
 import com.nutomic.syncthingandroid.R;
 import com.nutomic.syncthingandroid.SyncthingApp;
+import com.nutomic.syncthingandroid.di.DefaultSharedPreferences;
 import com.nutomic.syncthingandroid.http.PollWebGuiAvailableTask;
 import com.nutomic.syncthingandroid.model.RunConditionCheckResult;
 import com.nutomic.syncthingandroid.util.ConfigXml;
@@ -159,7 +160,10 @@ public class SyncthingService extends Service {
     private final SyncthingServiceBinder mBinder = new SyncthingServiceBinder(this);
 
     @Inject NotificationHandler mNotificationHandler;
-    @Inject SharedPreferences mPreferences;
+
+    @Inject
+    @DefaultSharedPreferences
+    SharedPreferences mPreferences;
 
     /**
      * Object that must be locked upon accessing mCurrentState

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
@@ -9,6 +9,7 @@ import android.text.TextUtils;
 import android.util.Log;
 
 import com.nutomic.syncthingandroid.R;
+import com.nutomic.syncthingandroid.di.DefaultSharedPreferences;
 import com.nutomic.syncthingandroid.service.Constants;
 import com.nutomic.syncthingandroid.service.SyncthingRunnable;
 
@@ -54,7 +55,10 @@ public class ConfigXml {
     private static final int FOLDER_ID_APPENDIX_LENGTH = 4;
 
     private final Context mContext;
-    @Inject SharedPreferences mPreferences;
+
+    @Inject
+    @DefaultSharedPreferences
+    SharedPreferences mPreferences;
 
     private final File mConfigFile;
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/Languages.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/Languages.java
@@ -13,6 +13,7 @@ import android.text.TextUtils;
 
 import com.nutomic.syncthingandroid.R;
 import com.nutomic.syncthingandroid.SyncthingApp;
+import com.nutomic.syncthingandroid.di.DefaultSharedPreferences;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -34,7 +35,10 @@ public final class Languages {
     private static final Locale DEFAULT_LOCALE;
     public static final String PREFERENCE_LANGUAGE = "pref_current_language";
 
-    @Inject SharedPreferences mPreferences;
+    @Inject
+    @DefaultSharedPreferences
+    SharedPreferences mPreferences;
+
     private static Map<String, String> mAvailableLanguages;
 
     static {


### PR DESCRIPTION
# Description 
Refactor a bit the way the default preferences are provided by making it more explicit they are the default ones. There are only the default ones at the moment but it may change in the future.

In the next step I'd also want to make the `SyncthingModule` the single source of these SharedPreferences. 
At the moment there are 19 places where `PreferenceManager.getDefaultSharedPreferences(...)` is invoked.
There should be only one source of it, the SyncthingModule, and there should be only one way of getting these preferences: injecting them where needed.

# Changes
* move the dagger component and module to a dedicated package
* add an annotation, `DefaultSharedPreferences`, to distinguish which preferences are provided/injected
* annotate the provider function and injection sites with `DefaultSharedPreferences` 

Why differentiate between different SharedPrefernces?
For additional clarity.
It may not be needed now, as everything is stored inside a single instance of SharedPrefences, the default one, but we may want to change that in the future.
Ideally each feature screen that needs to store small bits of data should be able to do so in its own dedicated SharedPreferences instance (also dedicated xml file on the device) that is independent from other features. 
This also helps to decouple features as it's always painful to decouple screens that are tightly coupled because of same storage.
Example:
<img width="1337" alt="image" src="https://github.com/syncthing/syncthing-android/assets/6529875/0c3ab65d-f825-4997-90b0-d359d519002b">
The same key is used in five different places. Trying to modify anything related to that key in one screen may break unexpectedly functionalities in other screens.
This is fine for now, but we should strive to avoid this kind of accidental complexity in the future in my opinion.