### PR TITLE
Provide notification handler in device and folder activities

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/SyncthingApp.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/SyncthingApp.java
@@ -4,6 +4,9 @@ import android.app.Application;
 import android.os.StrictMode;
 
 import com.google.android.material.color.DynamicColors;
+import com.nutomic.syncthingandroid.di.DaggerComponent;
+import com.nutomic.syncthingandroid.di.DaggerDaggerComponent;
+import com.nutomic.syncthingandroid.di.SyncthingModule;
 import com.nutomic.syncthingandroid.util.Languages;
 
 import javax.inject.Inject;

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/DeviceActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/DeviceActivity.java
@@ -28,9 +28,11 @@ import androidx.core.content.ContextCompat;
 
 import com.google.gson.Gson;
 import com.nutomic.syncthingandroid.R;
+import com.nutomic.syncthingandroid.SyncthingApp;
 import com.nutomic.syncthingandroid.databinding.ActivityDeviceBinding;
 import com.nutomic.syncthingandroid.model.Connections;
 import com.nutomic.syncthingandroid.model.Device;
+import com.nutomic.syncthingandroid.service.NotificationHandler;
 import com.nutomic.syncthingandroid.service.SyncthingService;
 import com.nutomic.syncthingandroid.util.Compression;
 import com.nutomic.syncthingandroid.util.TextWatcherAdapter;
@@ -39,6 +41,8 @@ import com.nutomic.syncthingandroid.util.Util;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
+import javax.inject.Inject;
 
 /**
  * Shows device details and allows changing them.
@@ -136,9 +140,13 @@ public class DeviceActivity extends SyncthingActivity implements View.OnClickLis
         }
     };
 
+    @Inject
+    NotificationHandler mNotificationHandler;
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        ((SyncthingApp) getApplication()).component().inject(this);
         binding = ActivityDeviceBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
@@ -186,7 +194,7 @@ public class DeviceActivity extends SyncthingActivity implements View.OnClickLis
         super.onDestroy();
         SyncthingService syncthingService = getService();
         if (syncthingService != null) {
-            syncthingService.getNotificationHandler().cancelConsentNotification(getIntent().getIntExtra(EXTRA_NOTIFICATION_ID, 0));
+            mNotificationHandler.cancelConsentNotification(getIntent().getIntExtra(EXTRA_NOTIFICATION_ID, 0));
             syncthingService.unregisterOnServiceStateChangeListener(this::onServiceStateChange);
         }
         binding.id.removeTextChangedListener(mIdTextWatcher);
@@ -227,7 +235,7 @@ public class DeviceActivity extends SyncthingActivity implements View.OnClickLis
     private void onServiceConnected() {
         Log.v(TAG, "onServiceConnected");
         SyncthingService syncthingService = (SyncthingService) getService();
-        syncthingService.getNotificationHandler().cancelConsentNotification(getIntent().getIntExtra(EXTRA_NOTIFICATION_ID, 0));
+        mNotificationHandler.cancelConsentNotification(getIntent().getIntExtra(EXTRA_NOTIFICATION_ID, 0));
         syncthingService.registerOnServiceStateChangeListener(this::onServiceStateChange);
     }
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FirstStartActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FirstStartActivity.java
@@ -38,6 +38,7 @@ import com.google.android.material.color.MaterialColors;
 import com.nutomic.syncthingandroid.R;
 import com.nutomic.syncthingandroid.SyncthingApp;
 import com.nutomic.syncthingandroid.databinding.ActivityFirstStartBinding;
+import com.nutomic.syncthingandroid.di.DefaultSharedPreferences;
 import com.nutomic.syncthingandroid.service.Constants;
 import com.nutomic.syncthingandroid.util.PermissionUtil;
 import com.nutomic.syncthingandroid.util.Util;
@@ -75,6 +76,7 @@ public class FirstStartActivity extends Activity {
     private ActivityFirstStartBinding binding;
 
     @Inject
+    @DefaultSharedPreferences
     SharedPreferences mPreferences;
 
     @SuppressLint("ClickableViewAccessibility")

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
@@ -27,10 +27,12 @@ import android.widget.Toast;
 import com.google.android.material.materialswitch.MaterialSwitch;
 import com.google.gson.Gson;
 import com.nutomic.syncthingandroid.R;
+import com.nutomic.syncthingandroid.SyncthingApp;
 import com.nutomic.syncthingandroid.databinding.FragmentFolderBinding;
 import com.nutomic.syncthingandroid.model.Device;
 import com.nutomic.syncthingandroid.model.Folder;
 import com.nutomic.syncthingandroid.service.Constants;
+import com.nutomic.syncthingandroid.service.NotificationHandler;
 import com.nutomic.syncthingandroid.service.RestApi;
 import com.nutomic.syncthingandroid.service.SyncthingService;
 import com.nutomic.syncthingandroid.util.FileUtils;
@@ -50,6 +52,8 @@ import static android.util.TypedValue.COMPLEX_UNIT_DIP;
 import static android.view.Gravity.CENTER_VERTICAL;
 import static android.view.ViewGroup.LayoutParams.WRAP_CONTENT;
 import static com.nutomic.syncthingandroid.service.SyncthingService.State.ACTIVE;
+
+import javax.inject.Inject;
 
 /**
  * Shows folder details and allows changing them.
@@ -132,9 +136,13 @@ public class FolderActivity extends SyncthingActivity
         }
     };
 
+    @Inject
+    NotificationHandler mNotificationHandler;
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        ((SyncthingApp) getApplication()).component().inject(this);
         binding = FragmentFolderBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
@@ -283,7 +291,7 @@ public class FolderActivity extends SyncthingActivity
         super.onDestroy();
         SyncthingService syncthingService = getService();
         if (syncthingService != null) {
-            syncthingService.getNotificationHandler().cancelConsentNotification(getIntent().getIntExtra(EXTRA_NOTIFICATION_ID, 0));
+            mNotificationHandler.cancelConsentNotification(getIntent().getIntExtra(EXTRA_NOTIFICATION_ID, 0));
             syncthingService.unregisterOnServiceStateChangeListener(this::onServiceStateChange);
         }
         binding.label.removeTextChangedListener(mTextWatcher);
@@ -320,7 +328,7 @@ public class FolderActivity extends SyncthingActivity
     public void onServiceConnected() {
         Log.v(TAG, "onServiceConnected");
         SyncthingService syncthingService = (SyncthingService) getService();
-        syncthingService.getNotificationHandler().cancelConsentNotification(getIntent().getIntExtra(EXTRA_NOTIFICATION_ID, 0));
+        mNotificationHandler.cancelConsentNotification(getIntent().getIntExtra(EXTRA_NOTIFICATION_ID, 0));
         syncthingService.registerOnServiceStateChangeListener(this);
     }
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/MainActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/MainActivity.java
@@ -49,6 +49,7 @@ import android.widget.Toast;
 import com.annimon.stream.function.Consumer;
 import com.nutomic.syncthingandroid.R;
 import com.nutomic.syncthingandroid.SyncthingApp;
+import com.nutomic.syncthingandroid.di.DefaultSharedPreferences;
 import com.nutomic.syncthingandroid.fragments.DeviceListFragment;
 import com.nutomic.syncthingandroid.fragments.DrawerFragment;
 import com.nutomic.syncthingandroid.fragments.FolderListFragment;
@@ -102,7 +103,10 @@ public class MainActivity extends StateDialogActivity
 
     private ActionBarDrawerToggle mDrawerToggle;
     private DrawerLayout          mDrawerLayout;
-    @Inject SharedPreferences mPreferences;
+
+    @Inject
+    @DefaultSharedPreferences
+    SharedPreferences mPreferences;
 
     /**
      * Handles various dialogs based on current state.

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -27,6 +27,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
 import com.nutomic.syncthingandroid.R;
 import com.nutomic.syncthingandroid.SyncthingApp;
+import com.nutomic.syncthingandroid.di.DefaultSharedPreferences;
 import com.nutomic.syncthingandroid.model.Config;
 import com.nutomic.syncthingandroid.model.Device;
 import com.nutomic.syncthingandroid.model.Options;
@@ -103,7 +104,10 @@ public class SettingsActivity extends SyncthingActivity {
         private static final String KEY_ST_RESET_DELTAS = "st_reset_deltas";
 
         @Inject NotificationHandler mNotificationHandler;
-        @Inject SharedPreferences mPreferences;
+
+        @Inject
+        @DefaultSharedPreferences
+        SharedPreferences mPreferences;
 
         private PreferenceGroup    mCategoryRunConditions;
         private CheckBoxPreference mRunConditions;

--- a/app/src/main/java/com/nutomic/syncthingandroid/di/DaggerComponent.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/di/DaggerComponent.java
@@ -1,7 +1,9 @@
 package com.nutomic.syncthingandroid.di;
 
 import com.nutomic.syncthingandroid.SyncthingApp;
+import com.nutomic.syncthingandroid.activities.DeviceActivity;
 import com.nutomic.syncthingandroid.activities.FirstStartActivity;
+import com.nutomic.syncthingandroid.activities.FolderActivity;
 import com.nutomic.syncthingandroid.activities.FolderPickerActivity;
 import com.nutomic.syncthingandroid.activities.MainActivity;
 import com.nutomic.syncthingandroid.activities.SettingsActivity;
@@ -24,6 +26,10 @@ public interface DaggerComponent {
 
     void inject(SyncthingApp app);
     void inject(MainActivity activity);
+
+    void inject(DeviceActivity activity);
+
+    void inject(FolderActivity activity);
     void inject(FirstStartActivity activity);
     void inject(FolderPickerActivity activity);
     void inject(Languages languages);

--- a/app/src/main/java/com/nutomic/syncthingandroid/di/DaggerComponent.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/di/DaggerComponent.java
@@ -1,5 +1,6 @@
-package com.nutomic.syncthingandroid;
+package com.nutomic.syncthingandroid.di;
 
+import com.nutomic.syncthingandroid.SyncthingApp;
 import com.nutomic.syncthingandroid.activities.FirstStartActivity;
 import com.nutomic.syncthingandroid.activities.FolderPickerActivity;
 import com.nutomic.syncthingandroid.activities.MainActivity;

--- a/app/src/main/java/com/nutomic/syncthingandroid/di/DefaultSharedPreferences.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/di/DefaultSharedPreferences.java
@@ -1,0 +1,13 @@
+package com.nutomic.syncthingandroid.di;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+
+import javax.inject.Qualifier;
+
+@Qualifier
+@Retention(RUNTIME)
+public @interface DefaultSharedPreferences {
+
+}

--- a/app/src/main/java/com/nutomic/syncthingandroid/di/SyncthingModule.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/di/SyncthingModule.java
@@ -22,6 +22,7 @@ public class SyncthingModule {
 
     @Provides
     @Singleton
+    @DefaultSharedPreferences
     public SharedPreferences getPreferences() {
         return PreferenceManager.getDefaultSharedPreferences(mApp);
     }

--- a/app/src/main/java/com/nutomic/syncthingandroid/di/SyncthingModule.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/di/SyncthingModule.java
@@ -1,8 +1,9 @@
-package com.nutomic.syncthingandroid;
+package com.nutomic.syncthingandroid.di;
 
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 
+import com.nutomic.syncthingandroid.SyncthingApp;
 import com.nutomic.syncthingandroid.service.NotificationHandler;
 
 import javax.inject.Singleton;

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/EventProcessor.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/EventProcessor.java
@@ -21,6 +21,7 @@ import com.nutomic.syncthingandroid.R;
 import com.nutomic.syncthingandroid.SyncthingApp;
 import com.nutomic.syncthingandroid.activities.DeviceActivity;
 import com.nutomic.syncthingandroid.activities.FolderActivity;
+import com.nutomic.syncthingandroid.di.DefaultSharedPreferences;
 import com.nutomic.syncthingandroid.model.CompletionInfo;
 import com.nutomic.syncthingandroid.model.Device;
 import com.nutomic.syncthingandroid.model.Event;
@@ -60,8 +61,11 @@ public class EventProcessor implements  Runnable, RestApi.OnReceiveEventListener
 
     private final Context mContext;
     private final RestApi mApi;
-    @Inject SharedPreferences mPreferences;
     @Inject NotificationHandler mNotificationHandler;
+
+    @Inject
+    @DefaultSharedPreferences
+    SharedPreferences mPreferences;
 
     public EventProcessor(Context context, RestApi api) {
         ((SyncthingApp) context.getApplicationContext()).component().inject(this);

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/NotificationHandler.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/NotificationHandler.java
@@ -18,6 +18,7 @@ import com.nutomic.syncthingandroid.SyncthingApp;
 import com.nutomic.syncthingandroid.activities.FirstStartActivity;
 import com.nutomic.syncthingandroid.activities.LogActivity;
 import com.nutomic.syncthingandroid.activities.MainActivity;
+import com.nutomic.syncthingandroid.di.DefaultSharedPreferences;
 import com.nutomic.syncthingandroid.service.Constants;
 import com.nutomic.syncthingandroid.service.SyncthingService.State;
 
@@ -37,7 +38,6 @@ public class NotificationHandler {
     private static final String CHANNEL_PERSISTENT_WAITING = "03_syncthing_persistent_waiting";
 
     private final Context mContext;
-    @Inject SharedPreferences mPreferences;
     private final NotificationManager mNotificationManager;
     private final NotificationChannel mPersistentChannel;
     private final NotificationChannel mPersistentChannelWaiting;
@@ -45,6 +45,10 @@ public class NotificationHandler {
 
     private Boolean lastStartForegroundService = false;
     private Boolean appShutdownInProgress = false;
+
+    @Inject
+    @DefaultSharedPreferences
+    SharedPreferences mPreferences;
 
     public NotificationHandler(Context context) {
         ((SyncthingApp) context.getApplicationContext()).component().inject(this);

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/NotificationHandler.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/NotificationHandler.java
@@ -1,6 +1,5 @@
 package com.nutomic.syncthingandroid.service;
 
-import android.annotation.TargetApi;
 import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
@@ -19,7 +18,6 @@ import com.nutomic.syncthingandroid.activities.FirstStartActivity;
 import com.nutomic.syncthingandroid.activities.LogActivity;
 import com.nutomic.syncthingandroid.activities.MainActivity;
 import com.nutomic.syncthingandroid.di.DefaultSharedPreferences;
-import com.nutomic.syncthingandroid.service.Constants;
 import com.nutomic.syncthingandroid.service.SyncthingService.State;
 
 import javax.inject.Inject;

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/RunConditionMonitor.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/RunConditionMonitor.java
@@ -20,6 +20,7 @@ import androidx.annotation.Nullable;
 import android.util.Log;
 
 import com.nutomic.syncthingandroid.SyncthingApp;
+import com.nutomic.syncthingandroid.di.DefaultSharedPreferences;
 import com.nutomic.syncthingandroid.model.RunConditionCheckResult;
 
 import java.util.ArrayList;
@@ -59,8 +60,11 @@ public class RunConditionMonitor {
     }
 
     private final Context mContext;
-    @Inject SharedPreferences mPreferences;
     private ReceiverManager mReceiverManager;
+
+    @Inject
+    @DefaultSharedPreferences
+    SharedPreferences mPreferences;
 
     /**
      * Sending callback notifications through {@link OnRunConditionChangedListener} is enabled if not null.

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
@@ -14,6 +14,7 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import com.nutomic.syncthingandroid.R;
 import com.nutomic.syncthingandroid.SyncthingApp;
+import com.nutomic.syncthingandroid.di.DefaultSharedPreferences;
 import com.nutomic.syncthingandroid.service.Constants;
 import com.nutomic.syncthingandroid.util.Util;
 
@@ -56,9 +57,12 @@ public class SyncthingRunnable implements Runnable {
     private final File mSyncthingBinary;
     private String[] mCommand;
     private final File mLogFile;
-    @Inject SharedPreferences mPreferences;
     private final boolean mUseRoot;
     @Inject NotificationHandler mNotificationHandler;
+
+    @Inject
+    @DefaultSharedPreferences
+    SharedPreferences mPreferences;
 
     public enum Command {
         deviceid,           // Output the device ID to the command line.

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
@@ -12,6 +12,7 @@ import androidx.annotation.Nullable;
 import com.google.common.io.Files;
 import com.nutomic.syncthingandroid.R;
 import com.nutomic.syncthingandroid.SyncthingApp;
+import com.nutomic.syncthingandroid.di.DefaultSharedPreferences;
 import com.nutomic.syncthingandroid.http.PollWebGuiAvailableTask;
 import com.nutomic.syncthingandroid.model.RunConditionCheckResult;
 import com.nutomic.syncthingandroid.util.ConfigXml;
@@ -159,7 +160,10 @@ public class SyncthingService extends Service {
     private final SyncthingServiceBinder mBinder = new SyncthingServiceBinder(this);
 
     @Inject NotificationHandler mNotificationHandler;
-    @Inject SharedPreferences mPreferences;
+
+    @Inject
+    @DefaultSharedPreferences
+    SharedPreferences mPreferences;
 
     /**
      * Object that must be locked upon accessing mCurrentState

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
@@ -653,10 +653,6 @@ public class SyncthingService extends Service {
         return mCurrentCheckResult.get();
     }
 
-    public NotificationHandler getNotificationHandler() {
-        return mNotificationHandler;
-    }
-
     /**
      * Exports the local config and keys to {@link Constants#EXPORT_PATH}.
      */

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
@@ -9,6 +9,7 @@ import android.text.TextUtils;
 import android.util.Log;
 
 import com.nutomic.syncthingandroid.R;
+import com.nutomic.syncthingandroid.di.DefaultSharedPreferences;
 import com.nutomic.syncthingandroid.service.Constants;
 import com.nutomic.syncthingandroid.service.SyncthingRunnable;
 
@@ -54,7 +55,10 @@ public class ConfigXml {
     private static final int FOLDER_ID_APPENDIX_LENGTH = 4;
 
     private final Context mContext;
-    @Inject SharedPreferences mPreferences;
+
+    @Inject
+    @DefaultSharedPreferences
+    SharedPreferences mPreferences;
 
     private final File mConfigFile;
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/Languages.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/Languages.java
@@ -13,6 +13,7 @@ import android.text.TextUtils;
 
 import com.nutomic.syncthingandroid.R;
 import com.nutomic.syncthingandroid.SyncthingApp;
+import com.nutomic.syncthingandroid.di.DefaultSharedPreferences;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -34,7 +35,10 @@ public final class Languages {
     private static final Locale DEFAULT_LOCALE;
     public static final String PREFERENCE_LANGUAGE = "pref_current_language";
 
-    @Inject SharedPreferences mPreferences;
+    @Inject
+    @DefaultSharedPreferences
+    SharedPreferences mPreferences;
+
     private static Map<String, String> mAvailableLanguages;
 
     static {


### PR DESCRIPTION
wip, waiting for https://github.com/syncthing/syncthing-android/pull/2054 
to merge first 

Decouples a bit FolderActivity and DeviceActivity from SyncthingService by injecting NotificationHandler into them directly instead of relying on a method in SyncthingService to provide it for them.