### PR TITLE
Add another attempt to check write permissions on a folder (fixes #1971)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
@@ -9,6 +9,8 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import androidx.documentfile.provider.DocumentFile;
+
+import android.os.Environment;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
@@ -537,6 +539,10 @@ public class FolderActivity extends SyncthingActivity
          * Access level readwrite: folder can be configured "sendonly" or "sendreceive".
          */
         mCanWriteToPath = Util.nativeBinaryCanWriteToPath(FolderActivity.this, mFolder.path);
+        if(!mCanWriteToPath){
+           final File externalStorageDirectory = Environment.getExternalStorageDirectory();
+           mCanWriteToPath = Util.nativeBinaryCanWriteToPath2(externalStorageDirectory, mFolder.path);
+        }
         if (mCanWriteToPath) {
             binding.accessExplanationView.setText(R.string.folder_path_readwrite);
             binding.folderType.setEnabled(true);

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
@@ -9,7 +9,6 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import androidx.documentfile.provider.DocumentFile;
-
 import android.os.Environment;
 import android.text.Editable;
 import android.text.TextUtils;
@@ -539,7 +538,7 @@ public class FolderActivity extends SyncthingActivity
          * Access level readwrite: folder can be configured "sendonly" or "sendreceive".
          */
         mCanWriteToPath = Util.nativeBinaryCanWriteToPath(FolderActivity.this, mFolder.path);
-        if(!mCanWriteToPath){
+        if (!mCanWriteToPath){
            final File externalStorageDirectory = Environment.getExternalStorageDirectory();
            mCanWriteToPath = Util.nativeBinaryCanWriteToPath2(externalStorageDirectory, mFolder.path);
         }

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/Util.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/Util.java
@@ -185,7 +185,6 @@ public class Util {
         final String normalizedPath = absoluteFolderPath.replaceFirst("^~", externalStorageDir.getAbsolutePath());
 
         // Write permission test file
-        //final String touchFilePath = normalizedPath + "/" + TOUCH_FILE_NAME;
         File touchFile = new File(normalizedPath, TOUCH_FILE_NAME);
         final String touchFilePath = touchFile.getAbsolutePath();
         try{

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/Util.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/Util.java
@@ -175,7 +175,7 @@ public class Util {
      * Returns if the syncthing binary would be able to write a file into
      * the given folder given the configured access level.
      *
-     * This uses the Android-native File SDK
+     * This uses the Android-native File API
      */
     public static Boolean nativeBinaryCanWriteToPath2(File externalStorageDir, String absoluteFolderPath) {
         final String TOUCH_FILE_NAME = ".stwritetest";

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/Util.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/Util.java
@@ -175,19 +175,19 @@ public class Util {
      * Returns if the syncthing binary would be able to write a file into
      * the given folder given the configured access level.
      *
-     * This uses the Android-native File API
+     * This uses the Android-native File API.
      */
     public static Boolean nativeBinaryCanWriteToPath2(File externalStorageDir, String absoluteFolderPath) {
         final String TOUCH_FILE_NAME = ".stwritetest";
 
-        // normalize path replacing ~ with external storage directory
-        // this is consistent with what $HOME is set to in SyncthingRunnable
+        // Normalize path replacing ~ with external storage directory.
+        // This is consistent with what $HOME is set to in SyncthingRunnable.
         final String normalizedPath = absoluteFolderPath.replaceFirst("^~", externalStorageDir.getAbsolutePath());
 
-        // Write permission test file
+        // Write permission test file.
         File touchFile = new File(normalizedPath, TOUCH_FILE_NAME);
         final String touchFilePath = touchFile.getAbsolutePath();
-        try{
+        try {
             Boolean fileCreated = touchFile.createNewFile();
             Log.d(TAG, String.format("%s createNewFile result %b", touchFilePath, fileCreated));
             Boolean fileDeleted = touchFile.delete();
@@ -272,5 +272,4 @@ public class Util {
     {
         return new MaterialAlertDialogBuilder(context);
     }
-
 }

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/Util.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/Util.java
@@ -7,7 +7,6 @@ import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager.NameNotFoundException;
-import android.os.Build;
 import android.preference.PreferenceManager;
 import androidx.appcompat.app.AlertDialog;
 import android.util.Log;
@@ -173,6 +172,39 @@ public class Util {
     }
 
     /**
+     * Returns if the syncthing binary would be able to write a file into
+     * the given folder given the configured access level.
+     *
+     * This uses the Android-native File SDK
+     */
+    public static Boolean nativeBinaryCanWriteToPath2(File externalStorageDir, String absoluteFolderPath) {
+        final String TOUCH_FILE_NAME = ".stwritetest";
+
+        // normalize path replacing ~ with external storage directory
+        // this is consistent with what $HOME is set to in SyncthingRunnable
+        final String normalizedPath = absoluteFolderPath.replaceFirst("^~", externalStorageDir.getAbsolutePath());
+
+        // Write permission test file
+        //final String touchFilePath = normalizedPath + "/" + TOUCH_FILE_NAME;
+        File touchFile = new File(normalizedPath, TOUCH_FILE_NAME);
+        final String touchFilePath = touchFile.getAbsolutePath();
+        try{
+            Boolean fileCreated = touchFile.createNewFile();
+            Log.d(TAG, String.format("%s createNewFile result %b", touchFilePath, fileCreated));
+            Boolean fileDeleted = touchFile.delete();
+            Log.d(TAG, String.format("%s delete result %b", touchFilePath, fileDeleted));
+        } catch (IOException e) {
+            Log.e(TAG, String.format("Failed to write test file '%s'", touchFilePath), e);
+            return false;
+        }
+
+        // Detected we have write permission.
+        Log.i(TAG, String.format("Successfully wrote test file '%s'", touchFile));
+
+        return true;
+    }
+
+    /**
      * Run command in a shell and return the exit code.
      */
     public static int runShellCommand(String cmd, Boolean useRoot) {
@@ -241,4 +273,5 @@ public class Util {
     {
         return new MaterialAlertDialogBuilder(context);
     }
+
 }


### PR DESCRIPTION
# Description
Fixes issue https://github.com/syncthing/syncthing-android/issues/1971

# Changes
* Add another attempt to check write permissions on a folder translating `~` to `externalStorageDirectory`. 
  * ignores `Constants.PREF_USE_ROOT` 
  * uses `java.io.File` to check access instead of shelling out.

## Notes
This an unobtrusive change, leaving the existing write-access check in place.

I tested this on a Pixel 6 Pro with Android 14.
