### PR TITLE
Prefer injecting preferences instead of using PreferenceManager directly

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/DaggerComponent.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/DaggerComponent.java
@@ -4,6 +4,8 @@ import com.nutomic.syncthingandroid.activities.FirstStartActivity;
 import com.nutomic.syncthingandroid.activities.FolderPickerActivity;
 import com.nutomic.syncthingandroid.activities.MainActivity;
 import com.nutomic.syncthingandroid.activities.SettingsActivity;
+import com.nutomic.syncthingandroid.activities.ShareActivity;
+import com.nutomic.syncthingandroid.activities.ThemedAppCompatActivity;
 import com.nutomic.syncthingandroid.receiver.AppConfigReceiver;
 import com.nutomic.syncthingandroid.service.RunConditionMonitor;
 import com.nutomic.syncthingandroid.service.EventProcessor;
@@ -34,4 +36,6 @@ public interface DaggerComponent {
     void inject(AppConfigReceiver appConfigReceiver);
     void inject(RestApi restApi);
     void inject(SettingsActivity.SettingsFragment fragment);
+    void inject(ShareActivity activity);
+    void inject(ThemedAppCompatActivity activity);
 }

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FirstStartActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FirstStartActivity.java
@@ -21,7 +21,6 @@ import androidx.core.content.ContextCompat;
 import androidx.viewpager.widget.PagerAdapter;
 import androidx.viewpager.widget.ViewPager;
 
-import android.preference.PreferenceManager;
 import android.provider.Settings;
 import android.text.Html;
 import android.util.Log;

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FirstStartActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FirstStartActivity.java
@@ -240,7 +240,7 @@ public class FirstStartActivity extends Activity {
             case API_LEVEL_30:
                 // Skip if running as root, as that circumvents any Android FS restrictions.
                 return upgradedToApiLevel30()
-                        || PreferenceManager.getDefaultSharedPreferences(this).getBoolean(Constants.PREF_USE_ROOT, false);
+                        || mPreferences.getBoolean(Constants.PREF_USE_ROOT, false);
             case NOTIFICATION:
                 return isNotificationPermissionGranted();
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderPickerActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderPickerActivity.java
@@ -42,6 +42,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 
+import javax.inject.Inject;
+
 /**
  * Activity that allows selecting a directory in the local file system.
  */
@@ -67,6 +69,9 @@ public class FolderPickerActivity extends SyncthingActivity
      * Location of null means that the list of roots is displayed.
      */
     private File mLocation;
+
+    @Inject
+    SharedPreferences mPreferences;
 
     public static Intent createIntent(Context context, String initialDirectory, @Nullable String rootDirectory) {
         Intent intent = new Intent(context, FolderPickerActivity.class);
@@ -103,7 +108,7 @@ public class FolderPickerActivity extends SyncthingActivity
             displayRoot();
         }
 
-        Boolean prefUseRoot = PreferenceManager.getDefaultSharedPreferences(this).getBoolean(Constants.PREF_USE_ROOT, false);
+        Boolean prefUseRoot = mPreferences.getBoolean(Constants.PREF_USE_ROOT, false);
         if (!prefUseRoot) {
             Toast.makeText(this, R.string.kitkat_external_storage_warning, Toast.LENGTH_LONG)
                     .show();
@@ -133,8 +138,7 @@ public class FolderPickerActivity extends SyncthingActivity
             roots.add(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS));
 
             // Add paths that might not be accessible to Syncthing.
-            SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(this);
-            if (sp.getBoolean("advanced_folder_picker", false)) {
+            if (mPreferences.getBoolean("advanced_folder_picker", false)) {
                 Collections.addAll(roots, new File("/storage/").listFiles());
                 roots.add(new File("/"));
             }

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderPickerActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderPickerActivity.java
@@ -6,11 +6,10 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.IBinder;
-import android.preference.PreferenceManager;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -268,7 +268,6 @@ public class SettingsActivity extends SyncthingActivity {
             mHttpProxyAddress.setOnPreferenceChangeListener(this);
 
             /* Initialize summaries */
-            mPreferences = PreferenceManager.getDefaultSharedPreferences(getActivity());
             screen.findPreference(Constants.PREF_POWER_SOURCE).setSummary(mPowerSource.getEntry());
             String wifiSsidSummary = TextUtils.join(", ", mPreferences.getStringSet(Constants.PREF_WIFI_SSID_WHITELIST, new HashSet<>()));
             screen.findPreference(Constants.PREF_WIFI_SSID_WHITELIST).setSummary(TextUtils.isEmpty(wifiSsidSummary) ?

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -12,7 +12,6 @@ import android.preference.ListPreference;
 import android.preference.Preference;
 import android.preference.PreferenceGroup;
 import android.preference.PreferenceFragment;
-import android.preference.PreferenceManager;
 import android.preference.PreferenceScreen;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/ShareActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/ShareActivity.java
@@ -10,7 +10,6 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
-import android.preference.PreferenceManager;
 import android.provider.MediaStore;
 import android.text.TextUtils;
 import android.util.Log;

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/ThemedAppCompatActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/ThemedAppCompatActivity.java
@@ -2,7 +2,6 @@ package com.nutomic.syncthingandroid.activities;
 
 import android.content.SharedPreferences;
 import android.os.Bundle;
-import android.preference.PreferenceManager;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.app.AppCompatDelegate;
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/ThemedAppCompatActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/ThemedAppCompatActivity.java
@@ -6,7 +6,10 @@ import android.preference.PreferenceManager;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.app.AppCompatDelegate;
 
+import com.nutomic.syncthingandroid.SyncthingApp;
 import com.nutomic.syncthingandroid.service.Constants;
+
+import javax.inject.Inject;
 
 /**
  * Provides a themed instance of AppCompatActivity.
@@ -15,12 +18,15 @@ public class ThemedAppCompatActivity extends AppCompatActivity {
 
     private static final String FOLLOW_SYSTEM = "-1";
 
+    @Inject
+    SharedPreferences mPreferences;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        ((SyncthingApp) getApplication()).component().inject(this);
         // Load theme.
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
         //For api level below 28, Follow system fall backs to light mode
-        Integer prefAppTheme = Integer.parseInt(prefs.getString(Constants.PREF_APP_THEME, FOLLOW_SYSTEM));
+        Integer prefAppTheme = Integer.parseInt(mPreferences.getString(Constants.PREF_APP_THEME, FOLLOW_SYSTEM));
         AppCompatDelegate.setDefaultNightMode(prefAppTheme);
         super.onCreate(savedInstanceState);
     }


### PR DESCRIPTION
# Description
Prefer injecting preferences instead of using `PreferenceManager.getDefaultSharedPreferences(context)` directly.

# Changes
* replace `PreferenceManager.getDefaultSharedPreferences(context)` by injecting SharedPreferences instead
