### PR TITLE
Extend full description for all file access

### DIFF
--- a/app/src/main/play/listings/en-GB/full-description.txt
+++ b/app/src/main/play/listings/en-GB/full-description.txt
@@ -1,4 +1,6 @@
-Syncthing replaces proprietary sync and cloud services with something open, trustworthy and decentralized. Your data is your data alone and you deserve to choose where it is stored, if it is shared with some third party and how it's transmitted over the Internet.
+Syncthing replaces proprietary sync and cloud services with something open, trustworthy and decentralized. Your data is your data alone and you deserve to choose where it is stored, if it is shared with some third party and how it's transmitted over the internet.
+
+You can select any directory, including the user data directory itself, to let Syncthing sync the files there (subject to restrictions by Android and your device's vendor). That's why this app requests the permission to access all files. This allows you to keep all the data you need and create on your phone in sync with another of your devices (computer, another phone, etc.). This can serve many use cases, it's all up to you. Typically it can be used to manage files from that other device (e.g. restructure or delete files), as a step (!) to back up your (app) data (you need a dedicated backup program to actually secure your data on a synced device) or to help with migrating to a new device (just set up Syncthing there as well, and your data gets synced to that new device).
 
 Website: https://syncthing.net/
 


### PR DESCRIPTION
Apparently the core use-cases for which google play allows the use of the all file access permission needs to be prominently mentioned. It's thus not an entirely organic description, I quite closely followed those and tried to incorporate some words directly. While still keeping it (hopefully) quite readable and potentially useful to real users (while the main target is dumb compliance).
https://support.google.com/googleplay/android-developer/answer/10467955?visit_id=638568800696248236-2021199491&rd=1#zippy=%2Cpermitted-uses-of-the-all-files-access-permission

Also I realised we never update play information. I did it manually for now. If play gets unstuck, I'll add a a github actions pipeline to do google play description updates. Right now I don't feel like spending that time given the uncertain future of google play.